### PR TITLE
docs: add npx skills install command to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ Official Apify agent skills for web scraping, data extraction, and automation. W
 
 ## Installation
 
+```bash
+npx skills add apify/agent-skills
+```
+
 ### Claude Code
 
 ```bash


### PR DESCRIPTION
## Summary
- Added `npx skills add apify/agent-skills` as the main installation command in README

## Test plan
- [x] Verify README renders correctly with the new command

🤖 Generated with [Claude Code](https://claude.com/claude-code)