### PR TITLE
feat: add apify-linkedin-posts skill

### DIFF
--- a/skills/apify-linkedin-posts/SKILL.md
+++ b/skills/apify-linkedin-posts/SKILL.md
@@ -1,0 +1,187 @@
+---
+name: apify-linkedin-posts
+description: Scrape LinkedIn profile posts and generate a validated HTML report with post URLs and content. Extracts posts from the last 3 months, cross-validates via direct URL fetch, and outputs a styled, browser-ready report. Use when user asks to analyze LinkedIn activity, scrape profile posts, audit someone's LinkedIn content, or generate a LinkedIn posts report.
+---
+
+# LinkedIn Posts Report
+
+Scrape a LinkedIn profile's recent posts and generate a validated HTML report with post URLs and content.
+
+## Prerequisites
+(No need to check it upfront)
+
+- `.env` file with `APIFY_TOKEN`
+- Node.js 20.6+ (for native `--env-file` support)
+
+## Workflow
+
+Copy this checklist and track progress:
+
+```
+Task Progress:
+- [ ] Step 1: Parse LinkedIn profile URL and extract username
+- [ ] Step 2: Verify Apify connection
+- [ ] Step 3: Scrape profile details and posts
+- [ ] Step 4: Filter posts to last 3 months
+- [ ] Step 5: Validate data accuracy
+- [ ] Step 6: Generate HTML report
+- [ ] Step 7: Open report in browser
+```
+
+### Step 1: Parse LinkedIn Profile URL
+
+Extract the LinkedIn username from user input. Accept any of these formats:
+- Full URL: `https://www.linkedin.com/in/username/`
+- URL with locale: `https://www.linkedin.com/in/username/?locale=en_US`
+- Just the username: `username`
+
+Strip trailing slashes and query parameters to isolate the username.
+
+If no URL or username is provided, ask the user for the LinkedIn profile URL.
+
+### Step 2: Verify Apify Connection
+
+Test the Apify connection before proceeding:
+
+```bash
+node --env-file=.env -e "
+const token = process.env.APIFY_TOKEN;
+if (!token) { console.error('APIFY_TOKEN not found in .env'); process.exit(1); }
+fetch('https://api.apify.com/v2/users/me?token=' + token)
+  .then(r => r.json())
+  .then(d => { if (d.data) console.log('Connected as: ' + d.data.username); else throw new Error('Invalid token'); })
+  .catch(e => { console.error('Auth failed: ' + e.message); process.exit(1); });
+"
+```
+
+**If connection fails**, guide the user:
+
+1. Open the Apify sign-in page: `open https://console.apify.com/sign-in`
+2. After sign-in, get API token from: `open https://console.apify.com/account/integrations`
+3. Add token to `.env` file: `APIFY_TOKEN=your_token_here`
+4. Retry the connection test
+
+Do NOT proceed until the connection is confirmed.
+
+### Step 3: Scrape Profile Data
+
+Run **two actors in parallel** to scrape both profile details and posts.
+
+**Profile Posts** — Actor: `apimaestro/linkedin-profile-posts`
+
+```bash
+node --env-file=.env ${SKILL_PATH}/reference/scripts/run_actor.js \
+  --actor "apimaestro/linkedin-profile-posts" \
+  --input '{"username": "USERNAME", "limit": 100, "page_number": 1}' \
+  --output linkedin-posts-USERNAME.json \
+  --format json
+```
+
+**Profile Details** — Actor: `apimaestro/linkedin-profile-detail`
+
+```bash
+node --env-file=.env ${SKILL_PATH}/reference/scripts/run_actor.js \
+  --actor "apimaestro/linkedin-profile-detail" \
+  --input '{"username": "USERNAME"}' \
+  --output linkedin-profile-USERNAME.json \
+  --format json
+```
+
+Replace `USERNAME` with the extracted username.
+
+### Step 4: Filter Posts to Last 3 Months
+
+After both scripts complete:
+
+1. Read the posts JSON file
+2. Calculate the date 3 months before today
+3. Filter to only posts where `posted_at.date` is within the 3-month window
+4. Keep all post types: `regular` (original), `quote`, `repost`
+5. Note any significant posting gaps (>3 weeks with no activity)
+
+### Step 5: Validate Data Accuracy
+
+Spot-check **2 posts** for accuracy by fetching their direct LinkedIn URLs:
+- Pick one original post and one repost/quote if available
+- Compare the scraped text against what's visible on the public post page
+- Verify: author name, content text, approximate date
+- Flag any discrepancies
+
+Also verify that profile details (name, headline, company) match between the two data sources.
+
+**Note:** LinkedIn may block direct URL access with a login wall (HTTP 999). If validation fails, note that scraped data is from Apify's API and is likely accurate, but could not be independently verified.
+
+### Step 6: Generate HTML Report
+
+Create a self-contained HTML file at `linkedin-report-USERNAME.html` with these sections:
+
+#### Header
+- Full name, headline, location
+- About/bio summary (italic, left-bordered quote style)
+- Meta stats: follower count, connection count, premium status, report period, total posts found
+
+#### Posts Table
+| Column | Description |
+|--------|-------------|
+| # | Row number |
+| Date | Formatted as `Mon DD, YYYY` |
+| Post URL | Clickable "View post" link (`target="_blank"`) |
+| Content | **Bold**: person's own text. Gray/smaller: context about shared/quoted content |
+| Type | Color-coded badge: Original (green), Quote (blue), Repost (orange) |
+
+#### Validation Summary
+- Checkmark-styled bullet list of what was verified
+- Note box with posting pattern analysis: original vs quote/repost ratio, key content themes (2-4 categories), and any posting gaps
+
+#### Footer
+- "Generated on {date} via Apify + Agent Skills"
+
+#### Styling
+Use this design system for the HTML:
+- Background: `#f3f2ef` (LinkedIn-like)
+- Cards: `#fff`, `border-radius: 12px`, `box-shadow: 0 1px 3px rgba(0,0,0,0.08)`
+- Table header: `#1b1f23` background, white text, uppercase
+- Font: `-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif`
+- Max width: `960px`, centered
+- Badge colors: Original `#e6f4ea/#1e8e3e`, Quote `#e8f0fe/#1a73e8`, Repost `#fef3e0/#e8710a`
+- Self-contained with inline `<style>` (no external dependencies)
+
+### Step 7: Open Report and Summarize
+
+1. Open the report in the default browser: `open linkedin-report-USERNAME.html`
+2. Provide a text summary:
+   - Total posts in the 3-month window
+   - Breakdown by type (original/quote/repost)
+   - Key content themes observed
+   - Notable posting gaps
+   - Validation status
+
+## Actor Reference
+
+| Actor | Purpose | Pricing |
+|-------|---------|---------|
+| `apimaestro/linkedin-profile-posts` | Scrape posts with content, reactions, comments, media | ~$0.005/post |
+| `apimaestro/linkedin-profile-detail` | Full profile: experience, education, certifications | ~$0.005/profile |
+
+Both actors work without LinkedIn cookies or login credentials.
+
+## Error Handling
+
+| Error | Solution |
+|-------|----------|
+| `APIFY_TOKEN not found` | Create `.env` with `APIFY_TOKEN=your_token` |
+| `Actor not found` | Verify actor ID spelling |
+| `Run FAILED` | Check Apify console link in error output |
+| `0 posts returned` | Profile may be private or username is incorrect |
+| `WebFetch returns 999` | LinkedIn login wall — note scraped data is likely accurate |
+| `Timeout` | Reduce post limit or increase `--timeout` |
+
+## Example Usage
+
+```
+# Scrape posts for a LinkedIn profile
+/linkedin-posts https://www.linkedin.com/in/satyanadella/
+
+# Using just the username
+/linkedin-posts satyanadella
+```

--- a/skills/apify-linkedin-posts/reference/scripts/run_actor.js
+++ b/skills/apify-linkedin-posts/reference/scripts/run_actor.js
@@ -1,0 +1,364 @@
+#!/usr/bin/env node
+/**
+ * Apify Actor Runner - Runs Apify actors and exports results.
+ *
+ * Usage:
+ *   # Quick answer (display in chat, no file saved)
+ *   node --env-file=.env scripts/run_actor.js --actor ACTOR_ID --input '{}'
+ *
+ *   # Export to file
+ *   node --env-file=.env scripts/run_actor.js --actor ACTOR_ID --input '{}' --output leads.csv --format csv
+ */
+
+import { parseArgs } from 'node:util';
+import { writeFileSync, statSync } from 'node:fs';
+
+// User-Agent for tracking skill usage in Apify analytics
+const USER_AGENT = 'apify-agent-skills/apify-linkedin-posts-1.0.0';
+
+// Parse command-line arguments
+function parseCliArgs() {
+    const options = {
+        actor: { type: 'string', short: 'a' },
+        input: { type: 'string', short: 'i' },
+        output: { type: 'string', short: 'o' },
+        format: { type: 'string', short: 'f', default: 'csv' },
+        timeout: { type: 'string', short: 't', default: '600' },
+        'poll-interval': { type: 'string', default: '5' },
+        help: { type: 'boolean', short: 'h' },
+    };
+
+    const { values } = parseArgs({ options, allowPositionals: false });
+
+    if (values.help) {
+        printHelp();
+        process.exit(0);
+    }
+
+    if (!values.actor) {
+        console.error('Error: --actor is required');
+        printHelp();
+        process.exit(1);
+    }
+
+    if (!values.input) {
+        console.error('Error: --input is required');
+        printHelp();
+        process.exit(1);
+    }
+
+    return {
+        actor: values.actor,
+        input: values.input,
+        output: values.output,
+        format: values.format || 'csv',
+        timeout: parseInt(values.timeout, 10),
+        pollInterval: parseInt(values['poll-interval'], 10),
+    };
+}
+
+function printHelp() {
+    console.log(`
+Apify Actor Runner - Run Apify actors and export results
+
+Usage:
+  node --env-file=.env scripts/run_actor.js --actor ACTOR_ID --input '{}'
+
+Options:
+  --actor, -a       Actor ID (e.g., apimaestro/linkedin-profile-posts) [required]
+  --input, -i       Actor input as JSON string [required]
+  --output, -o      Output file path (optional - if not provided, displays quick answer)
+  --format, -f      Output format: csv, json (default: csv)
+  --timeout, -t     Max wait time in seconds (default: 600)
+  --poll-interval   Seconds between status checks (default: 5)
+  --help, -h        Show this help message
+
+Output Formats:
+  JSON (all data)     --output file.json --format json
+  CSV (all data)      --output file.csv --format csv
+  Quick answer        (no --output) - displays top 5 in chat
+
+Examples:
+  # Export LinkedIn posts to JSON
+  node --env-file=.env scripts/run_actor.js \\
+    --actor "apimaestro/linkedin-profile-posts" \\
+    --input '{"username": "satyanadella", "limit": 100, "page_number": 1}' \\
+    --output linkedin-posts.json --format json
+
+  # Export LinkedIn profile to JSON
+  node --env-file=.env scripts/run_actor.js \\
+    --actor "apimaestro/linkedin-profile-detail" \\
+    --input '{"username": "satyanadella"}' \\
+    --output linkedin-profile.json --format json
+`);
+}
+
+// Start an actor run and return { runId, datasetId }
+async function startActor(token, actorId, inputJson) {
+    // Convert "author/actor" format to "author~actor" for API compatibility
+    const apiActorId = actorId.replace('/', '~');
+    const url = `https://api.apify.com/v2/acts/${apiActorId}/runs?token=${encodeURIComponent(token)}`;
+
+    let data;
+    try {
+        data = JSON.parse(inputJson);
+    } catch (e) {
+        console.error(`Error: Invalid JSON input: ${e.message}`);
+        process.exit(1);
+    }
+
+    const response = await fetch(url, {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json',
+            'User-Agent': `${USER_AGENT}/start_actor`,
+        },
+        body: JSON.stringify(data),
+    });
+
+    if (response.status === 404) {
+        console.error(`Error: Actor '${actorId}' not found`);
+        process.exit(1);
+    }
+
+    if (!response.ok) {
+        const text = await response.text();
+        console.error(`Error: API request failed (${response.status}): ${text}`);
+        process.exit(1);
+    }
+
+    const result = await response.json();
+    return {
+        runId: result.data.id,
+        datasetId: result.data.defaultDatasetId,
+    };
+}
+
+// Poll run status until complete or timeout
+async function pollUntilComplete(token, runId, timeout, interval) {
+    const url = `https://api.apify.com/v2/actor-runs/${runId}?token=${encodeURIComponent(token)}`;
+    const startTime = Date.now();
+    let lastStatus = null;
+
+    while (true) {
+        const response = await fetch(url);
+        if (!response.ok) {
+            const text = await response.text();
+            console.error(`Error: Failed to get run status: ${text}`);
+            process.exit(1);
+        }
+
+        const result = await response.json();
+        const status = result.data.status;
+
+        // Only print when status changes
+        if (status !== lastStatus) {
+            console.log(`Status: ${status}`);
+            lastStatus = status;
+        }
+
+        if (['SUCCEEDED', 'FAILED', 'ABORTED', 'TIMED-OUT'].includes(status)) {
+            return status;
+        }
+
+        const elapsed = (Date.now() - startTime) / 1000;
+        if (elapsed > timeout) {
+            console.error(`Warning: Timeout after ${timeout}s, actor still running`);
+            return 'TIMED-OUT';
+        }
+
+        await sleep(interval * 1000);
+    }
+}
+
+// Download dataset items
+async function downloadResults(token, datasetId, outputPath, format) {
+    const url = `https://api.apify.com/v2/datasets/${datasetId}/items?token=${encodeURIComponent(token)}&format=json`;
+
+    const response = await fetch(url, {
+        headers: {
+            'User-Agent': `${USER_AGENT}/download_${format}`,
+        },
+    });
+
+    if (!response.ok) {
+        const text = await response.text();
+        console.error(`Error: Failed to download results: ${text}`);
+        process.exit(1);
+    }
+
+    const data = await response.json();
+
+    if (format === 'json') {
+        writeFileSync(outputPath, JSON.stringify(data, null, 2));
+    } else {
+        // CSV output
+        if (data.length > 0) {
+            const fieldnames = Object.keys(data[0]);
+            const csvLines = [fieldnames.join(',')];
+
+            for (const row of data) {
+                const values = fieldnames.map((key) => {
+                    let value = row[key];
+
+                    // Truncate long text fields
+                    if (typeof value === 'string' && value.length > 200) {
+                        value = value.slice(0, 200) + '...';
+                    } else if (Array.isArray(value) || (typeof value === 'object' && value !== null)) {
+                        value = JSON.stringify(value) || '';
+                    }
+
+                    // CSV escape: wrap in quotes if contains comma, quote, or newline
+                    if (value === null || value === undefined) {
+                        return '';
+                    }
+                    const strValue = String(value);
+                    if (strValue.includes(',') || strValue.includes('"') || strValue.includes('\n')) {
+                        return `"${strValue.replace(/"/g, '""')}"`;
+                    }
+                    return strValue;
+                });
+                csvLines.push(values.join(','));
+            }
+
+            writeFileSync(outputPath, csvLines.join('\n'));
+        } else {
+            writeFileSync(outputPath, '');
+        }
+    }
+
+    console.log(`Saved to: ${outputPath}`);
+}
+
+// Display top 5 results in chat format
+async function displayQuickAnswer(token, datasetId) {
+    const url = `https://api.apify.com/v2/datasets/${datasetId}/items?token=${encodeURIComponent(token)}&format=json`;
+
+    const response = await fetch(url, {
+        headers: {
+            'User-Agent': `${USER_AGENT}/quick_answer`,
+        },
+    });
+
+    if (!response.ok) {
+        const text = await response.text();
+        console.error(`Error: Failed to download results: ${text}`);
+        process.exit(1);
+    }
+
+    const data = await response.json();
+    const total = data.length;
+
+    if (total === 0) {
+        console.log('\nNo results found.');
+        return;
+    }
+
+    // Display top 5
+    console.log(`\n${'='.repeat(60)}`);
+    console.log(`TOP 5 RESULTS (of ${total} total)`);
+    console.log('='.repeat(60));
+
+    for (let i = 0; i < Math.min(5, data.length); i++) {
+        const item = data[i];
+        console.log(`\n--- Result ${i + 1} ---`);
+
+        for (const [key, value] of Object.entries(item)) {
+            let displayValue = value;
+
+            // Truncate long values
+            if (typeof value === 'string' && value.length > 100) {
+                displayValue = value.slice(0, 100) + '...';
+            } else if (Array.isArray(value) || (typeof value === 'object' && value !== null)) {
+                const jsonStr = JSON.stringify(value);
+                displayValue = jsonStr.length > 100 ? jsonStr.slice(0, 100) + '...' : jsonStr;
+            }
+
+            console.log(`  ${key}: ${displayValue}`);
+        }
+    }
+
+    console.log(`\n${'='.repeat(60)}`);
+    if (total > 5) {
+        console.log(`Showing 5 of ${total} results.`);
+    }
+    console.log(`Full data available at: https://console.apify.com/storage/datasets/${datasetId}`);
+    console.log('='.repeat(60));
+}
+
+// Report summary of downloaded data
+function reportSummary(outputPath, format) {
+    const stats = statSync(outputPath);
+    const size = stats.size;
+
+    let count;
+    try {
+        const content = require('fs').readFileSync(outputPath, 'utf-8');
+        if (format === 'json') {
+            const data = JSON.parse(content);
+            count = Array.isArray(data) ? data.length : 1;
+        } else {
+            // CSV - count lines minus header
+            const lines = content.split('\n').filter((line) => line.trim());
+            count = Math.max(0, lines.length - 1);
+        }
+    } catch {
+        count = 'unknown';
+    }
+
+    console.log(`Records: ${count}`);
+    console.log(`Size: ${size.toLocaleString()} bytes`);
+}
+
+// Helper: sleep for ms
+function sleep(ms) {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+// Main function
+async function main() {
+    // Parse args first so --help works without token
+    const args = parseCliArgs();
+
+    // Check for APIFY_TOKEN
+    const token = process.env.APIFY_TOKEN;
+    if (!token) {
+        console.error('Error: APIFY_TOKEN not found in .env file');
+        console.error('');
+        console.error('Add your token to .env file:');
+        console.error('  APIFY_TOKEN=your_token_here');
+        console.error('');
+        console.error('Get your token: https://console.apify.com/account/integrations');
+        process.exit(1);
+    }
+
+    // Start the actor run
+    console.log(`Starting actor: ${args.actor}`);
+    const { runId, datasetId } = await startActor(token, args.actor, args.input);
+    console.log(`Run ID: ${runId}`);
+    console.log(`Dataset ID: ${datasetId}`);
+
+    // Poll for completion
+    const status = await pollUntilComplete(token, runId, args.timeout, args.pollInterval);
+
+    if (status !== 'SUCCEEDED') {
+        console.error(`Error: Actor run ${status}`);
+        console.error(`Details: https://console.apify.com/actors/runs/${runId}`);
+        process.exit(1);
+    }
+
+    // Determine output mode
+    if (args.output) {
+        // File output mode
+        await downloadResults(token, datasetId, args.output, args.format);
+        reportSummary(args.output, args.format);
+    } else {
+        // Quick answer mode - display in chat
+        await displayQuickAnswer(token, datasetId);
+    }
+}
+
+main().catch((err) => {
+    console.error(`Error: ${err.message}`);
+    process.exit(1);
+});


### PR DESCRIPTION
## Summary

- Adds new `apify-linkedin-posts` skill that scrapes LinkedIn profile posts and generates a validated HTML report
- Uses `apimaestro/linkedin-profile-posts` and `apimaestro/linkedin-profile-detail` Actors (no cookies/login required)
- Extracts posts from the last 3 months with post URLs and content
- Cross-validates scraped data via direct LinkedIn URL fetch
- Outputs a styled, self-contained HTML report opened in the browser

## What's included

- `skills/apify-linkedin-posts/SKILL.md` — Skill definition with full workflow (auth check, scrape, filter, validate, generate report)
- `skills/apify-linkedin-posts/reference/scripts/run_actor.js` — Actor runner script (adapted from existing skills)

## Test plan

- [ ] Run skill with a public LinkedIn profile URL
- [ ] Verify posts are filtered to last 3 months
- [ ] Verify HTML report generates correctly and opens in browser
- [ ] Verify auth check catches missing `APIFY_TOKEN`
- [ ] Update `marketplace.json` and regenerate `AGENTS.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)