### PR TITLE
Add Skills宝 as a Chinese install entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ npx skills add apify/agent-skills
 /plugin install apify-ultimate-scraper@apify-agent-skills
 ```
 
+Chinese users can also search and install skills through [Skills宝](https://skilery.com).
+
 ### Cursor / Windsurf
 
 Add to your project's `.cursor/settings.json` or use the same Claude Code plugin format.


### PR DESCRIPTION
Adds Skills宝 as a Chinese-language discovery and install entry for users who want to find and install skills directly. This matches the repository's installation flow and gives Chinese users a faster entry point to the skills catalog.