### PR TITLE
feat(ultimate-scraper): tag CLI invocations with --user-agent for telemetry attribution

### DIFF
--- a/skills/apify-ultimate-scraper/SKILL.md
+++ b/skills/apify-ultimate-scraper/SKILL.md
@@ -7,11 +7,14 @@ description: Universal AI-powered web scraper for any platform. Scrape data from
 
 AI-driven data extraction from ~100 Actors across 15+ platforms via the Apify CLI.
 
-**Rule: Always pass `--json` and redirect stderr with `2>/dev/null` to CLI commands.** JSON output is stable across CLI versions. stderr contains progress messages that break JSON parsers if not redirected.
+**Rules for every `apify` command:**
+1. Pass `--json` for machine-readable output (stable across CLI versions).
+2. Pass `--user-agent apify-agent-skills/apify-ultimate-scraper` for telemetry attribution.
+3. Redirect stderr with `2>/dev/null` (stderr contains progress messages that break JSON parsers).
 
 ## Prerequisites
 
-- Apify CLI v1.4.0+ (`npm install -g apify-cli`)
+- Apify CLI v1.5.0+ (`npm install -g apify-cli`)
 - Authenticated session (see below)
 
 ## Authentication
@@ -51,7 +54,7 @@ If the task involves a multi-step pipeline, also read the matching workflow guid
 
 If no Actor matches in the index, search dynamically:
 
-    apify actors search "KEYWORDS" --json --limit 10 2>/dev/null
+    apify actors search "KEYWORDS" --user-agent apify-agent-skills/apify-ultimate-scraper --json --limit 10 2>/dev/null
 
 From results: `items[].username`/`items[].name` (Actor ID), `items[].title`, `items[].stats.totalUsers30Days`, `items[].currentPricingInfo.pricingModel`.
 
@@ -59,11 +62,11 @@ From results: `items[].username`/`items[].name` (Actor ID), `items[].title`, `it
 
 Fetch the input schema dynamically:
 
-    apify actors info "ACTOR_ID" --input --json 2>/dev/null
+    apify actors info "ACTOR_ID" --user-agent apify-agent-skills/apify-ultimate-scraper --input --json 2>/dev/null
 
 Also read `references/gotchas.md` to check for common pitfalls for the selected Actor.
 
-For Actor documentation: `apify actors info "ACTOR_ID" --readme`
+For Actor documentation: `apify actors info "ACTOR_ID" --user-agent apify-agent-skills/apify-ultimate-scraper --readme`
 
 ### Step 3: Configure and run
 
@@ -73,15 +76,15 @@ For larger tasks, confirm output format (quick answer / CSV / JSON) and result c
 
 **Standard run (blocking):**
 
-    apify actors call "ACTOR_ID" -i 'JSON_INPUT' --json 2>/dev/null
+    apify actors call "ACTOR_ID" -i 'JSON_INPUT' --user-agent apify-agent-skills/apify-ultimate-scraper --json 2>/dev/null
 
 From output: `.id` (run ID), `.status`, `.defaultDatasetId`, `.stats.durationMillis`
 
 **Fetch results:**
 
-    apify datasets get-items DATASET_ID --format json
+    apify datasets get-items DATASET_ID --user-agent apify-agent-skills/apify-ultimate-scraper --format json
 
-For CSV: `apify datasets get-items DATASET_ID --format csv`
+For CSV: `apify datasets get-items DATASET_ID --user-agent apify-agent-skills/apify-ultimate-scraper --format csv`
 
 **Quick answer mode:** Fetch results as JSON, pick top 5, present formatted in chat.
 
@@ -89,9 +92,9 @@ For CSV: `apify datasets get-items DATASET_ID --format csv`
 
 **Large/long-running scrapes:**
 
-    apify actors start "ACTOR_ID" -i 'JSON_INPUT' --json 2>/dev/null
+    apify actors start "ACTOR_ID" -i 'JSON_INPUT' --user-agent apify-agent-skills/apify-ultimate-scraper --json 2>/dev/null
 
-Poll: `apify runs info RUN_ID --json 2>/dev/null` (check `.status` for `SUCCEEDED`).
+Poll: `apify runs info RUN_ID --user-agent apify-agent-skills/apify-ultimate-scraper --json 2>/dev/null` (check `.status` for `SUCCEEDED`).
 
 ### Step 4: Deliver results
 

--- a/skills/apify-ultimate-scraper/references/actor-index.md
+++ b/skills/apify-ultimate-scraper/references/actor-index.md
@@ -1,7 +1,7 @@
 # Actor index
 
 Flat lookup for Actor selection. For input schemas, fetch dynamically:
-`apify actors info "ACTOR_ID" --input --json`
+`apify actors info "ACTOR_ID" --user-agent apify-agent-skills/apify-ultimate-scraper --input --json`
 
 Tiers: `apify` = Apify-maintained (always prefer), `community` = community-maintained (fill gaps).
 

--- a/skills/apify-ultimate-scraper/references/gotchas.md
+++ b/skills/apify-ultimate-scraper/references/gotchas.md
@@ -10,7 +10,7 @@
 
 To check an Actor's pricing:
 
-    apify actors info "ACTOR_ID" --json
+    apify actors info "ACTOR_ID" --user-agent apify-agent-skills/apify-ultimate-scraper --json
 
 Read `.currentPricingInfo.pricingModel` and `.currentPricingInfo.pricePerEvent`.
 
@@ -34,7 +34,7 @@ Before running any PPE Actor:
 **Cookie-dependent Actors**
 Some social media scrapers require cookies or login sessions. If an Actor returns auth errors or empty results unexpectedly, check its README:
 
-    apify actors info "ACTOR_ID" --readme
+    apify actors info "ACTOR_ID" --user-agent apify-agent-skills/apify-ultimate-scraper --readme
 
 Look for mentions of "cookies", "login", "session", or "proxy".
 
@@ -58,8 +58,8 @@ Different Actors use different limit field names. Common variants:
 Always fetch the input schema to find the correct field for the specific Actor.
 
 **Deprecated Actors**
-Check `.isDeprecated` in `apify actors info --json`. If `true`:
-1. Search for alternatives: `apify actors search "SIMILAR_KEYWORDS" --json`
+Check `.isDeprecated` in `apify actors info "ACTOR_ID" --user-agent apify-agent-skills/apify-ultimate-scraper --json`. If `true`:
+1. Search for alternatives: `apify actors search "SIMILAR_KEYWORDS" --user-agent apify-agent-skills/apify-ultimate-scraper --json`
 2. Prefer `apify` tier replacements over `community` alternatives
 
 **LinkedIn pricing**
@@ -77,9 +77,9 @@ Always compare pricing before selecting a LinkedIn Actor.
 | Symptom | Likely cause | Fix |
 |---------|-------------|-----|
 | `status: FAILED` in run output | Actor crashed or input invalid | Read `.statusMessage` in JSON; check run log at `https://console.apify.com/actors/runs/RUN_ID/log` |
-| `isDeprecated: true` in Actor info | Actor is end-of-life | Search for replacement: `apify actors search "KEYWORDS" --json` |
-| Empty dataset (0 items) | Query too narrow, geo-restriction, or anti-bot block | Broaden search terms; enable Apify Proxy; check Actor README with `apify actors info ACTOR_ID --readme` |
-| Run takes >10 minutes | Large scrape or slow target site | Switch to fire-and-forget: `apify actors start --json`, poll with `apify runs info RUN_ID --json` |
+| `isDeprecated: true` in Actor info | Actor is end-of-life | Search for replacement: `apify actors search "KEYWORDS" --user-agent apify-agent-skills/apify-ultimate-scraper --json` |
+| Empty dataset (0 items) | Query too narrow, geo-restriction, or anti-bot block | Broaden search terms; enable Apify Proxy; check Actor README with `apify actors info ACTOR_ID --user-agent apify-agent-skills/apify-ultimate-scraper --readme` |
+| Run takes >10 minutes | Large scrape or slow target site | Switch to fire-and-forget: `apify actors start --user-agent apify-agent-skills/apify-ultimate-scraper --json`, poll with `apify runs info RUN_ID --user-agent apify-agent-skills/apify-ultimate-scraper --json` |
 
 ## Why Apify Actors vs raw HTTP scraping
 

--- a/skills/apify-ultimate-scraper/references/workflows/company-research.md
+++ b/skills/apify-ultimate-scraper/references/workflows/company-research.md
@@ -28,7 +28,7 @@ WCC crawl at depth 2 can return 20-50 pages per company. For large batches, set 
 ### Pipeline
 1. **Scrape Product Hunt launches** -> `apify/web-scraper`
    - Key input: `startUrls` (Product Hunt today/weekly/topic pages), `maxCrawlPages` (3-5)
-   - Note: no dedicated Actor exists - search `apify actors search "product hunt"` for community options
+   - Note: no dedicated Actor exists - search `apify actors search "product hunt" --user-agent apify-agent-skills/apify-ultimate-scraper` for community options
 2. **Filter by category + upvote threshold** (n8n: Filter node on extracted `upvotes`, `category`)
 3. **Crawl company sites** -> `apify/website-content-crawler`
    - Pipe: `results[].website` -> `startUrls`

--- a/skills/apify-ultimate-scraper/references/workflows/ecommerce-price-monitoring.md
+++ b/skills/apify-ultimate-scraper/references/workflows/ecommerce-price-monitoring.md
@@ -40,7 +40,7 @@ Many e-commerce sites use bot protection. If `e-commerce-scraping-tool` returns 
 Flat per-result pricing. 50 ASINs daily ~ $0.10-$0.25/run.
 
 ### Gotcha
-Amazon aggressively rotates prices and sometimes shows regional prices. Always store `currency` alongside `price`. For review text (not just counts), search `apify actors search "amazon reviews"` for a dedicated Actor.
+Amazon aggressively rotates prices and sometimes shows regional prices. Always store `currency` alongside `price`. For review text (not just counts), search `apify actors search "amazon reviews" --user-agent apify-agent-skills/apify-ultimate-scraper` for a dedicated Actor.
 
 ---
 

--- a/skills/apify-ultimate-scraper/references/workflows/job-market-and-recruitment.md
+++ b/skills/apify-ultimate-scraper/references/workflows/job-market-and-recruitment.md
@@ -61,7 +61,7 @@ Job descriptions contain implicit buying signals - tech stack mentions, pain poi
 Step 1: `title`, `description`, `budget`, `clientJobsPosted`, `clientHireRate`, `postedAt`, `url`
 
 ### Gotcha
-No dedicated Upwork Actor exists in Apify Store - verify with `apify actors search "upwork"` for community options before defaulting to `apify/playwright-scraper`. Upwork pages are JS-heavy so Playwright is required over basic HTTP scraping. For high-frequency monitoring (every 15 min), store seen job URLs to avoid re-processing duplicates.
+No dedicated Upwork Actor exists in Apify Store - verify with `apify actors search "upwork" --user-agent apify-agent-skills/apify-ultimate-scraper` for community options before defaulting to `apify/playwright-scraper`. Upwork pages are JS-heavy so Playwright is required over basic HTTP scraping. For high-frequency monitoring (every 15 min), store seen job URLs to avoid re-processing duplicates.
 
 ## GitHub contributor discovery
 **When:** User wants to find developers who contribute to specific open-source projects.

--- a/skills/apify-ultimate-scraper/references/workflows/real-estate-and-hospitality.md
+++ b/skills/apify-ultimate-scraper/references/workflows/real-estate-and-hospitality.md
@@ -61,7 +61,7 @@ Step 1: raw HTML / structured page data
 Step 2: `projectName`, `price`, `location`, `possessionDate`, `constructionStatus`
 
 ### Gotcha
-No market-specific Actor exists for most construction portals (e.g., 99acres). Run `apify actors search "real estate"` to check for community-built options before using `apify/playwright-scraper`. For JS-heavy portals, `playwright-scraper` is required. Step 2 cleans raw output into structured fields - pipe all Step 1 URLs through it.
+No market-specific Actor exists for most construction portals (e.g., 99acres). Run `apify actors search "real estate" --user-agent apify-agent-skills/apify-ultimate-scraper` to check for community-built options before using `apify/playwright-scraper`. For JS-heavy portals, `playwright-scraper` is required. Step 2 cleans raw output into structured fields - pipe all Step 1 URLs through it.
 
 ## Multi-source property comparison
 **When:** User wants to compare listings across Zillow, Realtor, Zumper, and other US/UK sources.


### PR DESCRIPTION
## Summary
- Adds `--user-agent apify-agent-skills/apify-ultimate-scraper` to every `apify` CLI example across the skill: 8 in `SKILL.md`, 8 inserts (across 7 example locations) in `references/gotchas.md`, 1 in `references/actor-index.md`, and 4 inline mentions in workflow guidance files (company-research, ecommerce-price-monitoring, job-market-and-recruitment, real-estate-and-hospitality).
- Adds a top-level rule in `SKILL.md` (alongside the existing `--json` rule) so agents that construct ad-hoc commands still emit the flag.
- Bumps the CLI prerequisite from `v1.4.0+` → `v1.5.0+` (the flag was merged in [apify/apify-cli#1102](https://github.com/apify/apify-cli/pull/1102) and shipped in `v1.5.0`).

## Why
The CLI now emits a caller-id field (`properties.userAgent`) on every `cli_command_*` Segment event. Tagging skill-driven invocations lets us measure agent-skills usage in Mixpanel separately from generic human CLI usage. Value matches the existing `apify-agent-skills/<slug>` naming convention so future cross-pipeline continuity is automatic.

## Scope
- Only `apify-ultimate-scraper` is instrumented in this PR. Development-focused skills (`apify-actor-development`, `apify-actorization`, `apify-generate-output-schema`) will be tagged separately.
- Flag is silently rejected on the `actor` entrypoint, which the skill never invokes — non-issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)