### PR TITLE
docs(skills): mirror AGENTS.md updates in actor-development and actorization

### DIFF
--- a/skills/apify-actor-development/SKILL.md
+++ b/skills/apify-actor-development/SKILL.md
@@ -129,13 +129,50 @@ See [references/logging.md](references/logging.md) for complete logging document
 ## Commands
 
 ```bash
-apify run          # Run Actor locally
-apify login        # Authenticate account
-apify push         # Deploy to Apify platform (uses name from .actor/actor.json)
-apify help         # List all commands
+# Bootstrap & local development
+apify create [name]                    # Create new Actor project from a template
+apify init                             # Initialize Actor in current directory
+apify run                              # Run Actor locally with simulated platform env
+apify run --purge                      # Run after clearing previous local storage
+apify validate-schema                  # Validate .actor/input_schema.json
+
+# Authentication & account
+apify login                            # Authenticate account (token stored in ~/.apify)
+apify logout                           # Remove stored credentials
+apify info                             # Print currently authenticated account info
+
+# Deployment & remote execution
+apify push                             # Deploy Actor to platform per .actor/actor.json
+apify pull <actor>                     # Download Actor code from the platform
+apify call <actor>                     # Execute Actor remotely on the platform
+apify actors build <actor>             # Create a new build of an Actor
+apify runs ls                          # List recent runs
+
+# Discovery (search Apify Store for community Actors)
+apify actors search "<query>" --user-agent <your-agent-name>
+apify actors info <actor>              # Details about a specific Actor
+
+# Secrets (referenced from actor.json via "@mySecret")
+apify secrets add <name> <value>       # Store a secret locally; uploaded on push
+apify secrets ls                       # List stored secret keys
+
+# Direct API access
+apify api <endpoint>                   # Authenticated HTTP request to Apify API
+
+# Help
+apify help                             # List all commands
+apify <command> --help                 # Detailed help for a specific command
 ```
 
+Note: If no dedicated Actor exists for your target, search Apify Store for community options with `apify actors search "<query>" --user-agent <your-agent-name>` before building from scratch.
+
+Tip: Inside a running Actor, prefer the SDK (`Actor.getInput()` / `Actor.get_input()`, `Actor.pushData()` / `Actor.push_data()`, `Actor.setValue()` / `Actor.set_value()`) over the equivalent `apify actor` runtime subcommands.
+
 **IMPORTANT:** Always use `apify run` to test Actors locally. Do not use `npm run start`, `npm start`, `yarn start`, or other package manager commands - these will not properly configure the Apify environment and storage.
+
+## Apify platform environment
+
+When the Actor runs on the Apify platform, the API token is automatically available via the `APIFY_TOKEN` environment variable (note: the variable is `APIFY_TOKEN`, not `APIFY_API_TOKEN`). The Apify SDK reads it automatically, so you do not need to pass it explicitly. Locally, run `apify login` once and the SDK will use your stored credentials.
 
 ## Local testing
 
@@ -206,14 +243,39 @@ See [references/actor-readme.md](references/actor-readme.md) for the required st
 - [Instagram Scraper](https://apify.com/apify/instagram-scraper)
 - [Google Maps Scraper](https://apify.com/compass/crawler-google-places)
 
-## Apify MCP tools
+## MCP tools
 
-If MCP server is configured, use these tools for documentation:
+### Apify MCP
+
+If the Apify MCP server is configured, use these tools for documentation:
 
 - `search-apify-docs` - Search documentation
 - `fetch-apify-docs` - Get full doc pages
 
 Otherwise, the MCP Server url: `https://mcp.apify.com/?tools=docs`.
+
+### Playwright MCP (debugging)
+
+The Playwright MCP server is a useful tool for debugging Actors that interact with the web - it lets the agent drive a real browser to inspect pages, capture selectors, and reproduce issues.
+
+Install with the Claude Code CLI:
+
+```bash
+claude mcp add playwright npx @playwright/mcp@latest
+```
+
+Or add it manually to your MCP config:
+
+```json
+{
+  "mcpServers": {
+    "playwright": {
+      "command": "npx",
+      "args": ["@playwright/mcp@latest"]
+    }
+  }
+}
+```
 
 ## Resources
 

--- a/skills/apify-actorization/SKILL.md
+++ b/skills/apify-actorization/SKILL.md
@@ -54,7 +54,9 @@ If not logged in, authenticate using OAuth (opens browser):
 apify login
 ```
 
-If browser login isn't available (headless environment or CI), ensure the `APIFY_TOKEN` environment variable is exported. The CLI reads it automatically - no explicit login needed. If the user doesn't have a token, generate one at https://console.apify.com/settings/integrations.
+If browser login isn't available (headless environment or CI), ensure the `APIFY_TOKEN` environment variable is exported (note: the variable is `APIFY_TOKEN`, not `APIFY_API_TOKEN`). The CLI reads it automatically - no explicit login needed. If the user doesn't have a token, generate one at https://console.apify.com/settings/integrations.
+
+> **Apify platform environment:** When the Actor runs on the Apify platform, `APIFY_TOKEN` is auto-injected as an environment variable and the Apify SDK reads it automatically — you do not need to pass it explicitly. Locally, `apify login` stores credentials in `~/.apify` and the SDK uses them.
 
 > **Security note:** Avoid passing tokens as command-line arguments (e.g. `apify login -t <token>`).
 > Arguments are visible in process listings and may be recorded in shell history.
@@ -198,14 +200,39 @@ Other options: **Rental** (monthly subscription) or **Free** (open source).
 - [ ] `README.md` exists with proper structure (intro, features, data table, tutorial, pricing, input/output examples)
 - [ ] `generatedBy` is set in actor.json meta section
 
-## Apify MCP tools
+## MCP tools
 
-If MCP server is configured, use these tools for documentation:
+### Apify MCP
+
+If the Apify MCP server is configured, use these tools for documentation:
 
 - `search-apify-docs` - Search documentation
 - `fetch-apify-docs` - Get full doc pages
 
 Otherwise, the MCP Server url: `https://mcp.apify.com/?tools=docs`.
+
+### Playwright MCP (debugging)
+
+The Playwright MCP server is a useful tool for debugging Actors that interact with the web - it lets the agent drive a real browser to inspect pages, capture selectors, and reproduce issues.
+
+Install with the Claude Code CLI:
+
+```bash
+claude mcp add playwright npx @playwright/mcp@latest
+```
+
+Or add it manually to your MCP config:
+
+```json
+{
+  "mcpServers": {
+    "playwright": {
+      "command": "npx",
+      "args": ["@playwright/mcp@latest"]
+    }
+  }
+}
+```
 
 ## Resources
 


### PR DESCRIPTION
## Summary
- Mirrors [apify/actor-templates#766](https://github.com/apify/actor-templates/pull/766) into the Actor development and Actorization skills.
- **actor-development:** expanded `## Commands` block (bootstrap, auth, deployment, Apify Store discovery via `apify actors search`, secrets, API), new `## Apify platform environment` section clarifying `APIFY_TOKEN` (not `APIFY_API_TOKEN`), and `## MCP tools` parent section with `### Apify MCP` and new `### Playwright MCP (debugging)` subsection.
- **actorization:** inline `APIFY_TOKEN` disambiguation plus the same `## MCP tools` / Playwright MCP restructure. Skipped the "search the store first" discovery — out of scope for converting existing code.
- Headings use sentence case (e.g., `## MCP tools`, `## Apify platform environment`) to match the surrounding files.

## Test plan
- [ ] Both SKILL.md files render correctly on GitHub
- [ ] No existing content was removed; only additions and the `## Apify MCP tools` → `## MCP tools` rename
- [ ] Heading capitalization stays consistent with the rest of each file

🤖 Generated with [Claude Code](https://claude.com/claude-code)