### PR TITLE
Add apify-sdk-integration skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -74,6 +74,21 @@
       "version": "2.0.0"
     },
     {
+      "name": "apify-sdk-integration",
+      "source": "./skills/apify-sdk-integration",
+      "skills": "./",
+      "description": "Integrate Apify into an existing JavaScript/TypeScript or Python application using the apify-client package. Use when adding web scraping, automation, or data extraction capabilities to an existing app via the Apify API",
+      "keywords": [
+        "apify",
+        "apify-client",
+        "integration",
+        "sdk",
+        "api"
+      ],
+      "category": "development",
+      "version": "2.0.0"
+    },
+    {
       "name": "apify-actor-commands",
       "description": "Commands for Apify Actor development workflow",
       "version": "2.0.0",

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 <p align="center">
   <a href="https://apify.com"><img src="https://img.shields.io/badge/Powered%20by-Apify-20A34E?style=for-the-badge" alt="Powered by Apify"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-Apache--2.0-555555?style=for-the-badge" alt="Apache 2.0"></a>
-  <a href="#skills"><img src="https://img.shields.io/badge/Skills-4-246DFF?style=for-the-badge" alt="4 Skills"></a>
+  <a href="#skills"><img src="https://img.shields.io/badge/Skills-5-246DFF?style=for-the-badge" alt="5 Skills"></a>
   <a href="https://apify.com/store"><img src="https://img.shields.io/badge/Actors-25%2C000%2B-F86606?style=for-the-badge" alt="25,000+ Actors"></a>
   <a href="https://mcp.apify.com/"><img src="https://img.shields.io/badge/MCP-Compatible-15C1E6?style=for-the-badge" alt="MCP Compatible"></a>
   <a href="https://github.com/apify/agent-skills/stargazers"><img src="https://img.shields.io/github/stars/apify/agent-skills?style=for-the-badge&color=9D97F4&label=Stars" alt="GitHub stars"></a>
@@ -37,6 +37,7 @@ Drop these skills into Claude Code, Cursor, Windsurf, Codex, or Gemini CLI and y
 - **Build new Actors** - generate, debug, and deploy serverless Actors in JavaScript, TypeScript, or Python with the official SDK patterns.
 - **Actorize existing code** - wrap any script, library, or CLI tool as a runnable Actor with proper input and output handling.
 - **Generate output schemas** - auto-derive `dataset_schema.json`, `output_schema.json`, and `key_value_store_schema.json` from existing Actor source.
+- **Integrate Apify into your app** - call Actors programmatically from existing JavaScript/TypeScript or Python applications via the `apify-client` package or REST API.
 
 > Looking for community-built, domain-specific skills (lead generation, brand monitoring, competitor intel, and more)? See [apify/awesome-skills](https://github.com/apify/awesome-skills).
 
@@ -66,6 +67,7 @@ That's it. The skill handles Actor selection, input shaping, run management, and
 | **[`apify-actor-development`](skills/apify-actor-development/)** | Create, debug, and deploy Apify Actors from scratch in JavaScript, TypeScript, or Python. Bundled references cover `actor.json`, input, output, dataset, and key-value schemas, logging, and standby mode. |
 | **[`apify-actorization`](skills/apify-actorization/)** | Convert existing code into Apify Actors. Supports the JS/TS SDK, the Python async context manager, and a generic CLI wrapper for any other language. |
 | **[`apify-generate-output-schema`](skills/apify-generate-output-schema/)** | Generate output schemas (`dataset_schema.json`, `output_schema.json`, `key_value_store_schema.json`) for an Actor by analyzing its source code. |
+| **[`apify-sdk-integration`](skills/apify-sdk-integration/)** | Integrate Apify into an existing JavaScript/TypeScript or Python application via the `apify-client` package. Covers sync and async execution, dataset and key-value store retrieval, error handling, and the REST API fallback for any other language. |
 
 Plus the **[`apify-actor-commands`](commands/)** pack, which adds slash commands like `/create-actor` for guided Actor scaffolding.
 
@@ -99,6 +101,7 @@ More patterns and the full launch story in [Introducing Apify Agent Skills](http
 /plugin install apify-actor-development@apify-agent-skills
 /plugin install apify-actorization@apify-agent-skills
 /plugin install apify-generate-output-schema@apify-agent-skills
+/plugin install apify-sdk-integration@apify-agent-skills
 ```
 
 ### Cursor and Windsurf

--- a/agents/AGENTS.md
+++ b/agents/AGENTS.md
@@ -6,6 +6,7 @@ These skills are:
  - apify-actor-development -> "skills/apify-actor-development/SKILL.md"
  - apify-actorization -> "skills/apify-actorization/SKILL.md"
  - apify-generate-output-schema -> "skills/apify-generate-output-schema/SKILL.md"
+ - apify-sdk-integration -> "skills/apify-sdk-integration/SKILL.md"
  - apify-ultimate-scraper -> "skills/apify-ultimate-scraper/SKILL.md"
 
 IMPORTANT: You MUST read the SKILL.md file whenever the description of the skills matches the user intent, or may help accomplish their task.
@@ -15,6 +16,7 @@ IMPORTANT: You MUST read the SKILL.md file whenever the description of the skill
 apify-actor-development: `Develop, debug, and deploy Apify Actors - serverless cloud programs for web scraping, automation, and data processing. Use when creating new Actors, modifying existing ones, or troubleshooting Actor code.`
 apify-actorization: `Convert existing projects into Apify Actors - serverless cloud programs. Actorize JavaScript/TypeScript (SDK with Actor.init/exit), Python (async context manager), or any language (CLI wrapper). Use when migrating code to Apify, wrapping CLI tools as Actors, or adding Actor SDK to existing projects.`
 apify-generate-output-schema: `Generate output schemas (dataset_schema.json, output_schema.json, key_value_store_schema.json) for an Apify Actor by analyzing its source code. Use when creating or updating Actor output schemas.`
+apify-sdk-integration: `Integrate Apify into an existing JavaScript/TypeScript or Python application using the apify-client package. Use when adding web scraping, automation, or data extraction capabilities to an existing app via the Apify API.`
 apify-ultimate-scraper: `Universal AI-powered web scraper for any platform. Scrape data from Instagram, Facebook, TikTok, YouTube, LinkedIn, X/Twitter, Google Maps, Google Search, Google Trends, Reddit, Airbnb, Yelp, and 15+ more platforms. Use for lead generation, brand monitoring, competitor analysis, influencer discovery, trend research, content analytics, audience analysis, review analysis, SEO intelligence, recruitment, or any data extraction task.`
 </available_skills>
 

--- a/skills/apify-sdk-integration/SKILL.md
+++ b/skills/apify-sdk-integration/SKILL.md
@@ -1,0 +1,210 @@
+---
+name: apify-sdk-integration
+description: Integrate Apify into an existing JavaScript/TypeScript or Python application using the apify-client package. Use when adding web scraping, automation, or data extraction capabilities to an existing app via the Apify API.
+---
+
+# Apify SDK Integration
+
+Add Apify Actor execution to an existing application. This skill covers the `apify-client` package for JS/TS and Python, plus the REST API for other languages.
+
+## When to Use This Skill
+
+- Adding web scraping or automation to an existing app
+- Calling Apify Actors programmatically from application code
+- Building a product that uses Apify as a backend service
+- Integrating Actor results into a data pipeline
+
+## Critical: Package Naming
+
+> **`apify-client`** is the API client for **calling** Actors from your app.
+> **`apify`** is the SDK for **building** Actors (wrong package for this use case).
+>
+> Always install `apify-client`. Never install `apify` for integration work.
+
+## Prerequisites
+
+The user needs an `APIFY_TOKEN`. Direct them to **Console > Settings > Integrations** at https://console.apify.com/settings/integrations to create one. If they don't have an account: https://console.apify.com/sign-up (free, no credit card).
+
+Store the token securely — environment variable or secrets manager, never hardcoded.
+
+## Finding the Right Actor
+
+Before writing integration code, find the Actor that fits the user's needs. Use the MCP tools if available:
+- `search-actors` — search the Apify Store by keyword
+- `fetch-actor-details` — get the Actor's input schema, output format, and pricing
+
+Alternatively, browse https://apify.com/store. Append `.md` to any Actor's Store URL to get its docs in markdown.
+
+## JavaScript / TypeScript
+
+### Install
+
+```bash
+npm install apify-client
+```
+
+### Synchronous Execution (wait for results)
+
+```typescript
+import { ApifyClient } from 'apify-client';
+
+const client = new ApifyClient({ token: process.env.APIFY_TOKEN });
+
+const run = await client.actor('apify/web-scraper').call({
+    startUrls: [{ url: 'https://example.com' }],
+    maxPagesPerCrawl: 10,
+});
+
+const { items } = await client.dataset(run.defaultDatasetId).listItems();
+```
+
+`.call()` blocks until the Actor finishes. Use for short-running Actors (under a few minutes).
+
+### Asynchronous Execution (start and poll/retrieve later)
+
+```typescript
+const run = await client.actor('apify/web-scraper').start({
+    startUrls: [{ url: 'https://example.com' }],
+});
+
+// Poll for completion
+const finishedRun = await client.run(run.id).waitForFinish();
+
+// Retrieve results
+const { items } = await client.dataset(finishedRun.defaultDatasetId).listItems();
+```
+
+Use `.start()` + `.waitForFinish()` for long-running Actors or when you need the run ID immediately.
+
+### Retrieving Results
+
+```typescript
+// Dataset items (structured data from pushData)
+const { items } = await client.dataset(run.defaultDatasetId).listItems({
+    limit: 100,
+    offset: 0,
+});
+
+// Key-value store (files, screenshots, etc.)
+const record = await client.keyValueStore(run.defaultKeyValueStoreId).getRecord('OUTPUT');
+```
+
+### Error Handling
+
+```typescript
+try {
+    const run = await client.actor('apify/web-scraper').call(input);
+
+    if (run.status !== 'SUCCEEDED') {
+        const log = await client.log(run.id).get();
+        throw new Error(`Actor failed with status ${run.status}: ${log}`);
+    }
+
+    const { items } = await client.dataset(run.defaultDatasetId).listItems();
+} catch (error) {
+    if (error.message?.includes('not found')) {
+        // Actor ID is wrong or Actor was deleted
+    } else if (error.statusCode === 401) {
+        // Invalid or missing APIFY_TOKEN
+    }
+    throw error;
+}
+```
+
+## Python
+
+### Install
+
+```bash
+pip install apify-client
+```
+
+### Synchronous Execution
+
+```python
+from apify_client import ApifyClient
+import os
+
+client = ApifyClient(token=os.environ['APIFY_TOKEN'])
+
+run = client.actor('apify/web-scraper').call(run_input={
+    'startUrls': [{'url': 'https://example.com'}],
+    'maxPagesPerCrawl': 10,
+})
+
+items = client.dataset(run['defaultDatasetId']).list_items().items
+```
+
+### Asynchronous Execution
+
+```python
+run = client.actor('apify/web-scraper').start(run_input={
+    'startUrls': [{'url': 'https://example.com'}],
+})
+
+# Poll for completion
+finished_run = client.run(run['id']).wait_for_finish()
+
+items = client.dataset(finished_run['defaultDatasetId']).list_items().items
+```
+
+### Async Client (asyncio)
+
+```python
+from apify_client import ApifyClientAsync
+
+client = ApifyClientAsync(token=os.environ['APIFY_TOKEN'])
+
+run = await client.actor('apify/web-scraper').call(run_input={
+    'startUrls': [{'url': 'https://example.com'}],
+})
+
+items = (await client.dataset(run['defaultDatasetId']).list_items()).items
+```
+
+## REST API (Any Language)
+
+For languages without an official client, use the REST API directly.
+
+### Start a Run
+
+```
+POST https://api.apify.com/v2/acts/{actorId}/runs
+Authorization: Bearer <APIFY_TOKEN>
+Content-Type: application/json
+
+{ "startUrls": [{ "url": "https://example.com" }] }
+```
+
+### Get Run Status
+
+```
+GET https://api.apify.com/v2/acts/{actorId}/runs/{runId}
+Authorization: Bearer <APIFY_TOKEN>
+```
+
+### Get Dataset Items
+
+```
+GET https://api.apify.com/v2/datasets/{datasetId}/items?format=json
+Authorization: Bearer <APIFY_TOKEN>
+```
+
+Full API reference: https://docs.apify.com/api/v2
+
+## Best Practices
+
+- **Set timeouts:** Pass `timeoutSecs` in the Actor input or use `waitSecs` on `.call()` to avoid indefinite waits.
+- **Paginate large datasets:** Use `limit` and `offset` when retrieving dataset items. Default limit is 250K items.
+- **Reuse clients:** Create one `ApifyClient` instance and reuse it across calls.
+- **Handle Actor-specific input:** Every Actor has its own input schema. Use `fetch-actor-details` MCP tool or append `.md` to the Actor's Store URL to get the schema before constructing input.
+
+## Documentation
+
+- Apify API client for JS: https://docs.apify.com/api/client/js
+- Apify API client for Python: https://docs.apify.com/api/client/python
+- REST API reference: https://docs.apify.com/api/v2
+- Apify docs (LLM-friendly): https://docs.apify.com/llms.txt
+- Apify docs (full): https://docs.apify.com/llms-full.txt
+
+If the Apify MCP server is available, use `search-apify-docs` and `fetch-apify-docs` tools for contextual documentation lookups during development.


### PR DESCRIPTION
## Summary

Imports the `apify-sdk-integration` skill from [apify/apify-plugins-internal](https://github.com/apify/apify-plugins-internal/tree/main/content/skills/apify-sdk-integration) into the user-facing `agent-skills` repo.

The skill covers the `apify-client` package for JS/TS and Python, plus the REST API for any other language: sync and async Actor execution, dataset and key-value store retrieval, error handling, and best practices.

## Changes

- Add `skills/apify-sdk-integration/SKILL.md` (copy from internal plugins repo)
- Register plugin in `.claude-plugin/marketplace.json` (`apify-sdk-integration`, category `development`, version `2.0.0`)
- Regenerate `agents/AGENTS.md` via `scripts/generate_agents.py` - now lists 5 skills
- Update `README.md`:
  - Skill count badge: 4 -> 5
  - Add capability bullet under Overview
  - Add row to Skills table
  - Add `/plugin install apify-sdk-integration@apify-agent-skills` to Claude Code install block

🤖 Generated with [Claude Code](https://claude.com/claude-code)