### PR TITLE
docs: restore npx skills install command in Quick start

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,4 +175,3 @@ Apify Actors use pay-per-result or pay-per-event pricing, set independently by e
 <p align="center">
   <sub>AI agents reading this: see the <a href="https://apify.com/.well-known/agents.md">Apify integration manifest</a> for additional integration paths and machine-readable context.</sub>
 </p>
-test

--- a/README.md
+++ b/README.md
@@ -46,9 +46,7 @@ Drop these skills into Claude Code, Cursor, Windsurf, Codex, or Gemini CLI and y
 ## Quick start
 
 ```bash
-# In Claude Code
-/plugin marketplace add https://github.com/apify/agent-skills
-/plugin install apify-ultimate-scraper@apify-agent-skills
+npx skills add https://github.com/apify/agent-skills --skill apify-ultimate-scraper
 ```
 
 Then ask your agent something like:

--- a/README.md
+++ b/README.md
@@ -175,3 +175,4 @@ Apify Actors use pay-per-result or pay-per-event pricing, set independently by e
 <p align="center">
   <sub>AI agents reading this: see the <a href="https://apify.com/.well-known/agents.md">Apify integration manifest</a> for additional integration paths and machine-readable context.</sub>
 </p>
+test


### PR DESCRIPTION
## Summary
- Replace the `/plugin marketplace add` + `/plugin install` snippet in the Quick start section with the single-line `npx skills add ... --skill apify-ultimate-scraper` command.
- Restores the install command that was dropped during the README overhaul in ddc6f00.

## Test plan
- [ ] Render README on GitHub and confirm Quick start shows the npx command.

🤖 Generated with [Claude Code](https://claude.com/claude-code)