### PR TITLE
docs: address four skill-doc issues from #50

### DIFF
--- a/evals/README.md
+++ b/evals/README.md
@@ -1,0 +1,104 @@
+# Agent-skills evals
+
+Eval-driven approach to improving these skills: prove a behavior gap with a
+failing eval *before* changing any skill file. Most routing fixes turn out to
+be a one-line `description` change — small, reviewable PRs, not rewrites.
+
+## Layout
+
+```
+evals/
+├── README.md                       (this file)
+├── routing.json                    cross-skill routing — which skill should be invoked?
+├── apify-actor-development.json    behavioral — once this skill is loaded, what should happen?
+├── apify-sdk-integration.json      behavioral
+└── apify-ultimate-scraper.json     behavioral
+```
+
+One file per skill. Within each per-skill file, every entry has a `type`
+field that categorizes the eval (e.g., `discovery`, `integrate`, `build`,
+`selection`, `run`, `cost`, `workflow:lead-generation`). Filter by `type`
+to focus on one area.
+
+## Schemas
+
+### `routing.json` — cross-skill routing
+
+Given the agent only sees skill names + descriptions (no skill bodies), does
+it pick the right skill for the prompt? Only `description` fields drive
+selection, so this layer tests descriptions.
+
+```json
+{
+  "prompt": "user input",
+  "expected_skill": "apify-sdk-integration",
+  "acceptable_skills": ["apify-ultimate-scraper"],
+  "rationale": "why this skill wins, and which overlap it disambiguates"
+}
+```
+
+- `expected_skill` — the single best skill.
+- `acceptable_skills` — optional; defensible alternates that count as a soft
+  pass. Use sparingly — many alternates means the descriptions overlap, which
+  is itself the finding.
+- A pick outside `expected_skill` ∪ `acceptable_skills` is a FAIL and points
+  at the description to fix.
+
+### `<skill>.json` — behavioral
+
+Given the skill **is** loaded, does the agent follow its intended commands,
+process, and conventions?
+
+```json
+{
+  "prompt": "user input",
+  "expected": "OUTCOME. Concrete, checkable steps the response must take.",
+  "type": "discovery"
+}
+```
+
+- `type` values used today:
+  - `apify-actor-development.json`: `build`, `cli`
+  - `apify-sdk-integration.json`: `discovery`, `integrate`
+  - `apify-ultimate-scraper.json`: `selection`, `schema-and-gotchas`, `run`,
+    `cost`, `workflow:<workflow-name>` (one per `references/workflows/*.md`)
+
+Workflow types use the `workflow:` prefix so a runner can filter all workflow
+evals at once (`startsWith("workflow:")`) while preserving which workflow a
+specific entry tests.
+
+## What "pass" means
+
+Borrowed from the skill-authoring guide — keep checks small and must-pass:
+
+- **Outcome** — did the task succeed (right skill chosen / right command run)?
+- **Process** — did it follow the intended tools/steps, not a lucky shortcut?
+- **Style** — does output follow the skill's conventions?
+- **Efficiency** — did it avoid thrashing (redundant searches, wrong-then-retry)?
+
+## Running
+
+In Claude Code:
+
+```
+Run evals/routing.json. For each entry, show the agent only the skill
+names+descriptions and the prompt; report which skill it picks vs
+expected_skill (acceptable_skills = soft pass). Summarize pass/fail and group
+failures by the description that needs work.
+```
+
+```
+Run evals/<skill>.json (optionally filter by type). For each entry, spawn an
+agent with that skill loaded and compare the response against `expected`.
+Report pass/fail.
+```
+
+## Counts
+
+| File | Entries |
+|------|--------:|
+| `routing.json` | 10 |
+| `apify-actor-development.json` | 8 |
+| `apify-sdk-integration.json` | 9 |
+| `apify-ultimate-scraper.json` | 89 |
+| **Total** | **116** |

--- a/evals/README.md
+++ b/evals/README.md
@@ -99,9 +99,9 @@ Report pass/fail.
 |------|--------:|
 | `routing.json` | 10 |
 | `apify-actor-development.json` | 8 |
-| `apify-sdk-integration.json` | 7 |
-| `apify-ultimate-scraper.json` | 79 |
-| **Total** | **104** |
+| `apify-sdk-integration.json` | 9 |
+| `apify-ultimate-scraper.json` | 88 |
+| **Total** | **115** |
 
 All prompts are written to stand on their own as **single-shot evals** — no
 prior turns, no implied conversational context. If a prompt would only make

--- a/evals/README.md
+++ b/evals/README.md
@@ -99,6 +99,11 @@ Report pass/fail.
 |------|--------:|
 | `routing.json` | 10 |
 | `apify-actor-development.json` | 8 |
-| `apify-sdk-integration.json` | 9 |
-| `apify-ultimate-scraper.json` | 89 |
-| **Total** | **116** |
+| `apify-sdk-integration.json` | 7 |
+| `apify-ultimate-scraper.json` | 79 |
+| **Total** | **104** |
+
+All prompts are written to stand on their own as **single-shot evals** — no
+prior turns, no implied conversational context. If a prompt would only make
+sense mid-conversation ("wrap up the run", "use this scraper", "from the
+search results"), it doesn't belong here.

--- a/evals/apify-actor-development.json
+++ b/evals/apify-actor-development.json
@@ -1,0 +1,42 @@
+[
+  {
+    "prompt": "There's no Apify Actor for this niche internal site. I need to scrape it.",
+    "expected": "DISCOVER BEFORE BUILD. Confirms no suitable Actor exists via `apify actors search` (broadening keywords once) before committing to build. Only then scaffolds a new Actor. Does NOT jump straight to writing scraper code without checking the Store.",
+    "type": "build"
+  },
+  {
+    "prompt": "Scaffold a new Apify Actor in TypeScript to crawl a static HTML site.",
+    "expected": "TEMPLATE SCAFFOLD / CORRECT PACKAGE. Uses `apify create <name> -t project_cheerio_crawler_ts` (the manifest `name` value — what `-t` actually accepts; the manifest `id` `ts-crawlee-cheerio` will error). Relies on the `apify` SDK (+ Crawlee), NOT `apify-client`. Does NOT hand-roll package.json / project structure from scratch.",
+    "type": "build"
+  },
+  {
+    "prompt": "The site I need to scrape is a heavy React SPA. Which template?",
+    "expected": "TEMPLATE CHOICE BY RENDERING NEED. Recommends a browser/JS-rendering template such as `project_playwright_crawler_ts` (or the JS/Python equivalent: `project_playwright_crawler_js`, `python-crawlee-playwright`), not the Cheerio/HTTP template, because the content is JavaScript-rendered. May mention camoufox variant (`project_playwright_camoufox_crawler_ts` / `python-crawlee-playwright-camoufox`) for anti-bot sites.",
+    "type": "build"
+  },
+  {
+    "prompt": "How do I read the Actor's input and output the scraped rows in my new Actor?",
+    "expected": "SDK PRIMITIVES. Uses the `apify` SDK lifecycle: read input with `await Actor.getInput()`, push results with `await Actor.pushData(...)`, inside `Actor.init()` / `Actor.exit()` (or `Actor.main()`). Does NOT use apify-client (that is for calling Actors, not authoring them).",
+    "type": "build"
+  },
+  {
+    "prompt": "What's the full list of templates I can scaffold from?",
+    "expected": "TEMPLATES SOURCE. States templates are chosen via `apify create` (interactive prompt) or `-t <id>`, and the canonical list lives in the actor-templates manifest (raw.githubusercontent.com/apify/actor-templates/master/templates/manifest.json). Does NOT claim a dedicated `apify templates list` subcommand.",
+    "type": "build"
+  },
+  {
+    "prompt": "I finished my Actor locally. How do I get it onto the Apify platform?",
+    "expected": "DEPLOY. Recommends `apify push` to build and deploy the Actor to the platform (after `apify login`). Confirms with the user before deploying. Does not conflate this with `apify actors call` (running an existing Actor).",
+    "type": "build"
+  },
+  {
+    "prompt": "Scrape product reviews from a niche forum that almost certainly has no existing Actor.",
+    "expected": "DISCOVER BEFORE BUILD. First attempts discovery via `apify actors search` once. On finding no suitable Actor, pivots to building a new one: uses `apify create <name> -t <template>` and selects a template (consulting the actor-templates manifest at raw.githubusercontent.com/apify/actor-templates/master/templates/manifest.json, or running `apify create` to list templates). Does NOT loop re-searching with many keyword variations.",
+    "type": "cli"
+  },
+  {
+    "prompt": "What CLI command lists the available Apify Actor templates?",
+    "expected": "TEMPLATES. Explains templates are selected via `apify create` (which prompts with the list) or `apify create <name> -t <template>`, and that the canonical list lives in the actor-templates repo manifest. Does NOT claim a non-existent dedicated 'list templates' subcommand.",
+    "type": "cli"
+  }
+]

--- a/evals/apify-sdk-integration.json
+++ b/evals/apify-sdk-integration.json
@@ -33,5 +33,15 @@
     "prompt": "I'm going to run the Amazon product Actor over 10,000 ASINs.",
     "expected": "PPE COST GATE. Notes the Amazon Actor is PAY_PER_EVENT, fetches/uses its pricing, estimates cost at that volume, and confirms with the user before running. Suggests batching. Does not silently launch a large paid run.",
     "type": "integrate"
+  },
+  {
+    "prompt": "I'm calling apify/website-content-crawler from my Node backend — runs take ~20 minutes. How do I trigger it without blocking the request?",
+    "expected": "ASYNC PATTERN. Recommends .start() to kick off the run (returns immediately with a run id) plus .waitForFinish() / wait_for_finish() to poll, rather than the blocking .call(). Retrieves results from the finished runs defaultDatasetId afterward.",
+    "type": "integrate"
+  },
+  {
+    "prompt": "I just called an Actor with .call() and have the returned run object. Where do I find the scraped data?",
+    "expected": "RESULT RETRIEVAL. Explains dataset items via client.dataset(run.defaultDatasetId).listItems() (with limit/offset for large sets), and key-value store via client.keyValueStore(run.defaultKeyValueStoreId).getRecord(OUTPUT) for files/screenshots.",
+    "type": "integrate"
   }
 ]

--- a/evals/apify-sdk-integration.json
+++ b/evals/apify-sdk-integration.json
@@ -25,11 +25,6 @@
     "type": "integrate"
   },
   {
-    "prompt": "This Actor takes ~20 minutes to finish. How should I run it from my app without blocking?",
-    "expected": "ASYNC PATTERN. Recommends `.start()` to kick off the run (returns immediately with a run id) plus `.waitForFinish()` / `wait_for_finish()` to poll, rather than the blocking `.call()`. Retrieves results from the finished run's defaultDatasetId afterward.",
-    "type": "integrate"
-  },
-  {
     "prompt": "Build a scraper that checks Amazon and Walmart for better deals.",
     "expected": "RECOGNIZE AS INTEGRATE, NOT BUILD. Discovers existing Actors for both retailers (e.g. junglee/Amazon-crawler, e-commerce/walmart-product-detail-scraper) instead of authoring scrapers. Identifies that the only custom code needed is the cross-retailer product-matching / price-comparison logic in the user's own app, fed by the two Actors' datasets. Does NOT use `apify create` / build an Actor.",
     "type": "integrate"
@@ -37,11 +32,6 @@
   {
     "prompt": "I'm going to run the Amazon product Actor over 10,000 ASINs.",
     "expected": "PPE COST GATE. Notes the Amazon Actor is PAY_PER_EVENT, fetches/uses its pricing, estimates cost at that volume, and confirms with the user before running. Suggests batching. Does not silently launch a large paid run.",
-    "type": "integrate"
-  },
-  {
-    "prompt": "Where do I get the scraped data after the run finishes?",
-    "expected": "RESULT RETRIEVAL. Explains dataset items via `client.dataset(run.defaultDatasetId).listItems()` (with limit/offset for large sets), and key-value store via `client.keyValueStore(run.defaultKeyValueStoreId).getRecord('OUTPUT')` for files/screenshots.",
     "type": "integrate"
   }
 ]

--- a/evals/apify-sdk-integration.json
+++ b/evals/apify-sdk-integration.json
@@ -1,0 +1,47 @@
+[
+  {
+    "prompt": "I need to scrape Instagram profile data. Find me an Apify Actor for it.",
+    "expected": "DISCOVER. Runs `apify actors search \"instagram profile\" --json --limit 10` (or similar keywords) to find an Actor. Reads the Actor ID from items[].username/items[].name in the JSON output. Does NOT guess or invent an Actor ID (e.g. 'apify/instagram-scraper') from memory. Presents candidate Actors with their IDs.",
+    "type": "discovery"
+  },
+  {
+    "prompt": "Use the apify/instagram-scraper Actor to get posts from a profile.",
+    "expected": "INSPECT BEFORE RUN. Fetches the input schema with `apify actors info apify/instagram-scraper --input --json` before constructing input or calling the Actor. Does NOT fabricate input field names from memory and call the Actor blind.",
+    "type": "discovery"
+  },
+  {
+    "prompt": "Find an Actor to scrape Google Maps listings, get its input schema, and show me how to run it.",
+    "expected": "FULL FLOW, NO THRASH. Executes the path exactly once each: search -> read Actor ID from JSON -> `apify actors info <id> --input --json` -> show run command (`apify actors call <id> -i '<json>' --json`). Total of ~3 CLI calls, not repeated searches or redundant info calls. Uses --json on machine-read commands.",
+    "type": "discovery"
+  },
+  {
+    "prompt": "Add Instagram scraping to my Node app using Apify.",
+    "expected": "INTEGRATE / CORRECT PACKAGE. Installs and imports `apify-client` (the API client), NOT `apify` (the Actor-building SDK). Constructs an ApifyClient with process.env.APIFY_TOKEN and calls an existing Instagram Actor. Does NOT scaffold or build a new Actor.",
+    "type": "integrate"
+  },
+  {
+    "prompt": "Call the apify/instagram-scraper Actor from Python and get the results.",
+    "expected": "SCHEMA THEN CALL. Fetches the input schema (`apify actors info apify/instagram-scraper --input --json`) before constructing run_input, then uses apify-client's `client.actor(id).call(run_input=...)` and reads items from `client.dataset(run['defaultDatasetId']).list_items().items`. Does NOT invent input field names.",
+    "type": "integrate"
+  },
+  {
+    "prompt": "This Actor takes ~20 minutes to finish. How should I run it from my app without blocking?",
+    "expected": "ASYNC PATTERN. Recommends `.start()` to kick off the run (returns immediately with a run id) plus `.waitForFinish()` / `wait_for_finish()` to poll, rather than the blocking `.call()`. Retrieves results from the finished run's defaultDatasetId afterward.",
+    "type": "integrate"
+  },
+  {
+    "prompt": "Build a scraper that checks Amazon and Walmart for better deals.",
+    "expected": "RECOGNIZE AS INTEGRATE, NOT BUILD. Discovers existing Actors for both retailers (e.g. junglee/Amazon-crawler, e-commerce/walmart-product-detail-scraper) instead of authoring scrapers. Identifies that the only custom code needed is the cross-retailer product-matching / price-comparison logic in the user's own app, fed by the two Actors' datasets. Does NOT use `apify create` / build an Actor.",
+    "type": "integrate"
+  },
+  {
+    "prompt": "I'm going to run the Amazon product Actor over 10,000 ASINs.",
+    "expected": "PPE COST GATE. Notes the Amazon Actor is PAY_PER_EVENT, fetches/uses its pricing, estimates cost at that volume, and confirms with the user before running. Suggests batching. Does not silently launch a large paid run.",
+    "type": "integrate"
+  },
+  {
+    "prompt": "Where do I get the scraped data after the run finishes?",
+    "expected": "RESULT RETRIEVAL. Explains dataset items via `client.dataset(run.defaultDatasetId).listItems()` (with limit/offset for large sets), and key-value store via `client.keyValueStore(run.defaultKeyValueStoreId).getRecord('OUTPUT')` for files/screenshots.",
+    "type": "integrate"
+  }
+]

--- a/evals/apify-ultimate-scraper.json
+++ b/evals/apify-ultimate-scraper.json
@@ -1,0 +1,447 @@
+[
+  {
+    "prompt": "Get me the trending videos on TikTok right now.",
+    "expected": "INDEX FIRST. Consults references/actor-index.md and selects a listed TikTok Actor (e.g. clockworks/tiktok-trends-scraper or clockworks/tiktok-scraper) by its ID. Does NOT guess an Actor ID from memory, and does not jump to a dynamic search when the index already covers TikTok.",
+    "type": "selection"
+  },
+  {
+    "prompt": "Scrape listings from a regional classifieds site that isn't a major platform.",
+    "expected": "DYNAMIC SEARCH FALLBACK. When the platform is not in actor-index.md, runs `apify actors search \"<keywords>\" --user-agent apify-agent-skills/apify-ultimate-scraper --json --limit 10 2>/dev/null` and reads candidates (items[].username/name, stats, currentPricingInfo) from the JSON. Selects based on relevance, popularity (totalUsers30Days), and pricing.",
+    "type": "selection"
+  },
+  {
+    "prompt": "From the search results, what's the Actor ID I should use?",
+    "expected": "ACTOR ID CONSTRUCTION. Builds the Actor ID by concatenating `{items[].username}/{items[].name}` (e.g. `apify/instagram-scraper`, `compass/crawler-google-places`, `clockworks/tiktok-scraper`). Does NOT fabricate IDs from memory (e.g. assuming `apify/google-maps-scraper` when the real top result is `compass/crawler-google-places`). Treats `username` and `name` as two separate JSON fields that must both be read.",
+    "type": "selection"
+  },
+  {
+    "prompt": "I need LinkedIn lead-generation data: companies, employees, and emails.",
+    "expected": "WORKFLOW RECOGNITION. Recognizes this matches the 'leads, contacts, emails, B2B' row in the Step 1 workflow trigger table, and additionally loads references/workflows/lead-generation.md before picking Actors. Does NOT pick a single LinkedIn Actor in isolation when a multi-step pipeline guide exists for the use case.",
+    "type": "selection"
+  },
+  {
+    "prompt": "The Actor I want to use shows isDeprecated: true. What now?",
+    "expected": "DEPRECATED HANDLING. Recognizes the Actor is end-of-life, searches for an alternative (`apify actors search \"<similar keywords>\" --user-agent apify-agent-skills/apify-ultimate-scraper --json`), and prefers an `apify`-tier (Apify/partner-maintained) replacement over a community one.",
+    "type": "selection"
+  },
+  {
+    "prompt": "There are several Instagram scrapers. Which should I pick?",
+    "expected": "TIER + SPECIFICITY. Prefers Apify-tier Actors (the `apify` column in actor-index.md, e.g. apify/instagram-scraper) over community ones, AND picks the variant matching the specific data need (profile vs post vs hashtag vs comments vs reels) rather than a single generic choice.",
+    "type": "selection"
+  },
+  {
+    "prompt": "I picked apify/instagram-scraper. Let's go.",
+    "expected": "SCHEMA BEFORE RUN. Fetches the input schema with `apify actors info \"apify/instagram-scraper\" --user-agent apify-agent-skills/apify-ultimate-scraper --input --json 2>/dev/null` to learn the correct input field names BEFORE constructing input. Does not invent input fields from memory.",
+    "type": "schema-and-gotchas"
+  },
+  {
+    "prompt": "Use this scraper to pull 500 Instagram posts.",
+    "expected": "GOTCHAS CHECK. Reads references/gotchas.md before running and applies relevant pitfalls — for Instagram specifically: keep maxResults under 200 per run (platform rate-limit guidance), expect platform-blocking without proxy, and verify field names with `--input --json` (some Actors use `resultsLimit`, others `maxItems`, others `maxResults`).",
+    "type": "schema-and-gotchas"
+  },
+  {
+    "prompt": "I'm getting empty results from this social-media Actor and I know the account exists.",
+    "expected": "COOKIE/AUTH DIAGNOSIS. Recognizes social-media scrapers commonly need cookies/login. Checks the Actor README (`apify actors info \"ACTOR_ID\" --user-agent apify-agent-skills/apify-ultimate-scraper --readme`) for mentions of `cookies`, `login`, `session`, or `proxy`. Suggests enabling Apify Proxy or providing session cookies if required. Does NOT assume the account doesn't exist.",
+    "type": "schema-and-gotchas"
+  },
+  {
+    "prompt": "How do I limit this to just 100 items? I tried `maxResults: 100` but it ignored me.",
+    "expected": "FIELD NAME VARIANCE. Explains that limit field names vary by Actor — common variants include `maxResults`, `resultsLimit`, `maxItems` (output items) vs `maxCrawledPages`, `maxRequestsPerCrawl` (pages visited). Tells the user to fetch the input schema with `--input --json` to find the correct field for THIS Actor, rather than guessing.",
+    "type": "schema-and-gotchas"
+  },
+  {
+    "prompt": "What's Nike's follower count on Instagram?",
+    "expected": "QUICK-ANSWER MODE. Treats this as a simple lookup: skips user-preference questions, runs the Actor in quick-answer mode (blocking `apify actors call ... --json`), and presents the single answer in chat. Does not prompt for output format / result count for a trivial lookup.",
+    "type": "run"
+  },
+  {
+    "prompt": "Run a large scrape that will take a while and let me check on it later.",
+    "expected": "ASYNC RUN. Uses `apify actors start \"ACTOR_ID\" -i '<json>' --user-agent apify-agent-skills/apify-ultimate-scraper --json 2>/dev/null` (fire-and-forget) and polls with `apify runs info RUN_ID --user-agent apify-agent-skills/apify-ultimate-scraper --json 2>/dev/null` checking .status for SUCCEEDED, rather than a blocking call that could time out.",
+    "type": "run"
+  },
+  {
+    "prompt": "Give me the results as a CSV file.",
+    "expected": "RETRIEVE + SAVE. Fetches results with `apify datasets get-items DATASET_ID --user-agent apify-agent-skills/apify-ultimate-scraper --format csv` and saves via the Write tool to a dated filename of the form `YYYY-MM-DD_descriptive-name.csv`. For JSON, uses --format json.",
+    "type": "run"
+  },
+  {
+    "prompt": "Okay, the run finished — wrap it up for me.",
+    "expected": "DELIVER. Reports result count, file location (if saved), key data fields, and BOTH console links: dataset (https://console.apify.com/storage/datasets/DATASET_ID) AND run (https://console.apify.com/actors/runs/RUN_ID). For multi-step workflows, suggests the next pipeline step from the workflow guide.",
+    "type": "run"
+  },
+  {
+    "prompt": "Search the store for a Yelp review scraper and show me options.",
+    "expected": "CLI CONVENTIONS. Follows the skill's mandatory command rules: passes `--json`, includes `--user-agent apify-agent-skills/apify-ultimate-scraper`, and redirects stderr with `2>/dev/null` so JSON parses cleanly. Applies these THREE rules to every apify command, not just search.",
+    "type": "run"
+  },
+  {
+    "prompt": "Scrape 2,000 results from this pay-per-event Actor.",
+    "expected": "PPE COST GATE + DISCLAIMER. Before running, reads .currentPricingInfo.pricePerEvent from `apify actors info`, multiplies by the requested count, and presents an estimate WITH the rough-estimate disclaimer language (mentions estimate-only, actual costs may vary with Actor/data/retries/platform changes, refers user to Apify billing dashboard for actual charges). Does not silently launch a paid run.",
+    "type": "cost"
+  },
+  {
+    "prompt": "Run this PPE Actor for 50,000 items.",
+    "expected": "HIGH-COST CONFIRMATION. Produces a cost estimate; since a large PPE run will exceed the thresholds, explicitly warns (>$5) and REQUIRES explicit user confirmation before proceeding (>$20). Suggests batching.",
+    "type": "cost"
+  },
+  {
+    "prompt": "I need to scrape LinkedIn profiles in bulk with emails.",
+    "expected": "LINKEDIN PRICING COMPARISON. Notes all LinkedIn Actors are PPE and compares cost tiers (harvestapi cheaper at $0.001-0.01/result, apimaestro pricier at $0.005-0.02/result, dev_fusion mid-range for mass + email enrichment) before selecting, rather than picking arbitrarily. Keeps batch sizes under platform limits (~100 profiles, 5+ minutes between runs).",
+    "type": "cost"
+  },
+  {
+    "prompt": "Run a SimilarWeb / Ahrefs / Moz scraper for 100 domains.",
+    "expected": "SEO PRICING AWARENESS. Recognizes radeance/ SEO scrapers (SimilarWeb, Ahrefs, SEMrush, Moz) are the highest per-result PPE cost ($0.005-0.0275/result), estimates the run carefully, and suggests batching for large-scale SEO analysis.",
+    "type": "cost"
+  },
+  {
+    "prompt": "This Actor's pricingModel is FLAT_PRICE_PER_MONTH. Can I just run it?",
+    "expected": "FLAT_PRICE SUBSCRIPTION CHECK. Recognizes FLAT_PRICE_PER_MONTH requires a monthly subscription, and verifies (or asks the user to verify) that they have an active subscription before attempting to run. Distinguishes from FREE (just run) and PAY_PER_EVENT (estimate first).",
+    "type": "cost"
+  },
+  {
+    "prompt": "Track all mentions of our brand across Instagram, Twitter, and Reddit.",
+    "expected": "CROSS-PLATFORM MENTION TRACKING (PARALLEL). Runs four Actors INDEPENDENTLY (not sequentially): apify/instagram-tagged-scraper (username=brand), apify/instagram-hashtag-scraper (branded hashtags), apidojo/tweet-scraper (searchTerms), trudax/reddit-scraper-lite (searchQuery=brand). Combines results by date for a timeline view. Recognizes this is a parallel workflow, not a pipe.",
+    "type": "workflow:brand-monitoring"
+  },
+  {
+    "prompt": "Route negative tweets about our brand to support and positive to wins, with sentiment scores.",
+    "expected": "TWITTER REAL-TIME ROUTING PIPELINE. Step 1: apidojo/tweet-scraper with searchTerms (brand + variants), maxItems, since (ISO date for incremental runs — store last tweet createdAt to avoid re-alerting on the same tweet). Step 2: tri_angle/social-media-sentiment-analysis-tool, piping results[].url -> urls, with platforms. Output sentiment + score routes to channels.",
+    "type": "workflow:brand-monitoring"
+  },
+  {
+    "prompt": "Weekly digest of brand and competitor mentions from Reddit.",
+    "expected": "REDDIT MONITORING. Single Actor: trudax/reddit-scraper-lite with subreddits + searchTerms (brand + competitors) + maxItems + sort. Uses sort='new' for monitoring runs, sort='top' for periodic digests — does not mix in one run.",
+    "type": "workflow:brand-monitoring"
+  },
+  {
+    "prompt": "Unified brand health view across IG, Facebook, TikTok, and Twitter with sentiment.",
+    "expected": "MULTI-PLATFORM SOCIAL LISTENING PIPELINE (PARALLEL + MERGE). Steps 1-4 run IN PARALLEL: apify/instagram-search-scraper, apify/facebook-search-scraper, clockworks/tiktok-user-search-scraper, apidojo/tweet-scraper (each with searchTerms + maxItems). Step 5: tri_angle/social-media-sentiment-analysis-tool fed with merged post URLs from steps 1-4 -> urls.",
+    "type": "workflow:brand-monitoring"
+  },
+  {
+    "prompt": "Score sentiment on the mentions I already collected.",
+    "expected": "SENTIMENT-ONLY. Single Actor: tri_angle/social-media-sentiment-analysis-tool with the existing post URLs piped to urls + platforms. Output: sentiment (positive/negative/neutral), score, text, platform. No re-collection needed.",
+    "type": "workflow:brand-monitoring"
+  },
+  {
+    "prompt": "We have a target account list. Give us firmographics, ICP signals, and key personnel for ABM.",
+    "expected": "ABM PROFILING PIPELINE. Step 1: apify/website-content-crawler on company domains with maxCrawlDepth=2 and includeUrlGlobs restricted to about/pricing/team/careers/blog (keeps cost manageable; max ~5 pages for large batches). Step 2: harvestapi/linkedin-company piped from extracted company name/URL (includeEmployees: false). Step 3: AI extracts companySize, industry, techStack, keyPersonnel, painSignals. Stores in Supabase/Airtable/HubSpot.",
+    "type": "workflow:company-research"
+  },
+  {
+    "prompt": "Weekly Product Hunt scouting for new startups in a target category.",
+    "expected": "PRODUCT HUNT SCOUTING PIPELINE. Step 1: apify/web-scraper on Product Hunt today/weekly/topic pages (no dedicated Actor; search Store for community options first). Step 2: filter by category + upvote threshold. Step 3: apify/website-content-crawler on results[].website, maxCrawlPages=3, includeUrlGlobs (about, team). Step 4: harvestapi/linkedin-profile-search for founders. Step 5: AI ICP scoring. Schedules scrape for end-of-day (11pm UTC) to capture final votes.",
+    "type": "workflow:company-research"
+  },
+  {
+    "prompt": "Brief me on the people in my 3pm sales meeting 30 minutes before it starts.",
+    "expected": "SALES MEETING PREP PIPELINE. Step 1: Google Calendar trigger (filter for events starting in 30 min). Step 2: harvestapi/linkedin-profile-scraper + harvestapi/linkedin-profile-posts on attendee LinkedIn URLs (maxPosts=5). Step 3: harvestapi/linkedin-company piped from results[].currentCompany. Step 4: apify/google-search-scraper for company news (maxResultsPerPage=5). Step 5: AI synthesizes brief. Delivered via Gmail/WhatsApp 30 min before. Notes attendee LinkedIn URLs MUST be in the calendar event or CRM (don't auto-resolve from email). Cost ~$0.05 per 2-attendee meeting.",
+    "type": "workflow:company-research"
+  },
+  {
+    "prompt": "Show me what ads my competitor is running.",
+    "expected": "COMPETITOR AD MONITORING. Single Actor: apify/facebook-ads-scraper with searchQuery (competitor name) + country + adType + maxItems. Notes Facebook Ad Library is public (no auth) but results are limited to currently active or recently inactive ads.",
+    "type": "workflow:competitive-intel"
+  },
+  {
+    "prompt": "Give me traffic, rankings, and backlink data for our top 5 competitors.",
+    "expected": "COMPETITOR WEB PRESENCE PIPELINE. Step 1: radeance/similarweb-scraper with urls (competitor domains) — globalRank, monthlyVisits, bounceRate, trafficSources. Step 2: radeance/ahrefs-scraper with the same urls — domainRating, backlinks, referringDomains, organicKeywords. Flags radeance/ Actors as $0.005-0.0275/result (estimate ~$0.04-0.06 per domain audit).",
+    "type": "workflow:competitive-intel"
+  },
+  {
+    "prompt": "Alert me when competitor pricing or feature pages change.",
+    "expected": "WEBSITE CHANGE DETECTION. Single Actor: tri_angle/website-changes-detector with startUrls (competitor pages) + notificationEmail + checkIntervalHours. Output: url, changedAt, diff, screenshotUrl. Does NOT attempt to manage baselines externally — the Actor handles baseline storage internally and external management loses diff history.",
+    "type": "workflow:competitive-intel"
+  },
+  {
+    "prompt": "Track our competitors' Google rankings for our target keywords weekly.",
+    "expected": "SERP POSITION MONITORING PIPELINE. Step 1: apify/google-search-scraper with queries (target keywords) + countryCode + maxResultsPerPage. Step 2: radeance/similarweb-scraper run SEPARATELY per competitor domain extracted from Step 1. Budgets ~$0.10-0.15 per weekly run for ~5 competitors.",
+    "type": "workflow:competitive-intel"
+  },
+  {
+    "prompt": "Build a structured comparison of competitor pricing tiers and features.",
+    "expected": "PRICING BENCHMARK PIPELINE. Step 1: apify/website-content-crawler on competitor pricing page URLs with maxCrawlDepth=1 AND includeUrlGlobs restricted to pricing/features paths (without this, WCC crawls the full site and cost balloons). Step 2: AI node extracts structured JSON (tiers, prices, feature flags, positioning) from results[].text.",
+    "type": "workflow:competitive-intel"
+  },
+  {
+    "prompt": "Get emails and social links from this list of company websites.",
+    "expected": "WEBSITE CONTACT EXTRACTION PIPELINE. Step 1: vdrmota/contact-info-scraper OR compass/contact-details-scraper-standby with startUrls + maxDepth (1-2). Step 2: apify/social-media-leads-analyzer piping results[].domain -> domains (extractLinkedIn, extractTwitter). Picks the standby Actor for real-time webhook latency (<1s), vdrmota for batch cost-efficiency.",
+    "type": "workflow:contact-enrichment"
+  },
+  {
+    "prompt": "Find warm leads from people who commented on this LinkedIn post.",
+    "expected": "LINKEDIN COMMENT ENRICHMENT PIPELINE. Step 1: harvestapi/linkedin-post-comments with postUrl + maxComments. Step 2: harvestapi/linkedin-profile-scraper piping results[].commenter.profileUrl -> urls, with includeEmail: true. Step 3: filter by ICP. Step 4: AI drafts outreach using commentText + headline. Flags PPE cost (~$1.50 for 100 commenters). Tests postUrl manually first — private/restricted posts return empty silently.",
+    "type": "workflow:contact-enrichment"
+  },
+  {
+    "prompt": "Auto-enrich every form submission with the company's data.",
+    "expected": "REAL-TIME FORM ENRICHMENT PIPELINE. Step 1: webhook trigger. Step 2: parse email domain (n8n Function). Step 3: apify/website-content-crawler with startUrls=domain, maxCrawlPages=3-5, includeUrlGlobs (about/pricing/careers/team). Step 4: harvestapi/linkedin-company for firmographics. Step 5: AI extracts ICPFit score. Step 6: route via Switch node. For latency-critical paths uses apify/cheerio-scraper on the About page only, skipping LinkedIn — WCC on a startup site takes 30-60s.",
+    "type": "workflow:contact-enrichment"
+  },
+  {
+    "prompt": "Crawl this docs site and give me clean text for our RAG pipeline.",
+    "expected": "WEBSITE TO RAG. Single Actor: apify/website-content-crawler with startUrls + maxCrawlPages + crawlerType ('cheerio' for static, 'playwright' for JS sites, apify/camoufox-scraper for anti-bot). Output: url, title, text, markdown, metadata.",
+    "type": "workflow:content-and-seo"
+  },
+  {
+    "prompt": "Generate an SEO content brief for the keyword \"agentic frameworks\".",
+    "expected": "SEO BRIEF PIPELINE. Step 1: apify/google-search-scraper with queries + countryCode + maxResultsPerPage. Step 2: apify/cheerio-scraper (NOT website-content-crawler — 10x faster for HTML-only heading extraction) piping results[].organicResults[].url -> startUrls (filter non-article URLs first), with pageFunction extracting h1/h2/h3.",
+    "type": "workflow:content-and-seo"
+  },
+  {
+    "prompt": "Build a topic inventory from our competitor's full sitemap.",
+    "expected": "SITEMAP AUDIT PIPELINE. Step 1: apify/sitemap-extractor with sitemap.xml URL. Step 2: apify/website-content-crawler piping results[].urls[] -> startUrls, with maxCrawlPages + htmlTransformer=readableText. FILTERS to a path prefix (e.g. /blog/) before Step 2 to avoid crawling tag archives/pagination on large sitemaps.",
+    "type": "workflow:content-and-seo"
+  },
+  {
+    "prompt": "Weekly keyword rank tracking with Slack alerts on drops >5 positions.",
+    "expected": "KEYWORD RANK TRACKING. Single Actor: apify/google-search-scraper with queries (tracked keywords) + countryCode + device + maxResultsPerPage SET TO 100 (default 10 misses positions 11-100 — without this you can't detect a drop from position 12 to 18). Fixed-cost Actor; ~$1-3/month for 100 keywords.",
+    "type": "workflow:content-and-seo"
+  },
+  {
+    "prompt": "Just give me the SERP for these queries.",
+    "expected": "SERP ANALYSIS. Single Actor: apify/google-search-scraper with queries + maxPagesPerQuery + countryCode + languageCode. Output: organicResults[], paidResults[], peopleAlsoAsk[], relatedSearches[].",
+    "type": "workflow:content-and-seo"
+  },
+  {
+    "prompt": "AI agent: research a question, crawl top sources, write a structured report.",
+    "expected": "DEEP RESEARCH AGENT PIPELINE. Step 1: LLM generates 3 search queries. Step 2: apify/google-search-scraper with the generated queries. Step 3: apify/rag-web-browser (NOT website-content-crawler — rag-web-browser is optimized for agent single-URL retrieval, clean markdown, lower latency) piping AI-selected relevant URLs. Step 4: LLM synthesis.",
+    "type": "workflow:content-and-seo"
+  },
+  {
+    "prompt": "Get domain authority and backlinks for these 50 domains.",
+    "expected": "DOMAIN AUTHORITY PIPELINE. Step 1: radeance/similarweb-scraper (traffic). Step 2: radeance/ahrefs-scraper (backlinks). Step 3: radeance/semrush-scraper (authority). All PPE at $0.005-0.0275/result; estimates ~$0.05-0.08/domain → ~$2.50-$4 for 50 domains. Confirms cost before running.",
+    "type": "workflow:content-and-seo"
+  },
+  {
+    "prompt": "Monitor competitor product prices daily and alert me on changes.",
+    "expected": "PRICE MONITORING PIPELINE. Step 1: apify/e-commerce-scraping-tool with startUrls (competitor product URLs) + proxyConfiguration. Step 2: tri_angle/e-commerce-product-matching-tool piping Step-1 dataset id + target list. Step 3: compute % change vs stored baseline. Step 4: alert on change. Cost ~$0.50-$1/run for 200 URLs. Falls back to apify/camoufox-scraper with residential proxy + sessionPoolName if prices come back empty.",
+    "type": "workflow:ecommerce-price-monitoring"
+  },
+  {
+    "prompt": "Monitor Walmart product prices for our top SKUs and alert on changes.",
+    "expected": "WALMART → ECOMMERCE PRICE MONITORING. Recognizes 'Walmart' + 'monitor prices' as the price-monitoring use case (matches the 'price monitoring, e-commerce, products' trigger row in SKILL.md Step 1). Follows the price-monitoring pipeline: Step 1 apify/e-commerce-scraping-tool with Walmart product URLs as startUrls + proxyConfiguration (or selects a Walmart-specific Actor from actor-index.md such as e-commerce/walmart-product-detail-scraper or e-commerce/walmart-fast-product-scraper if listed), Step 2 product matching if cross-retailer, Step 3 baseline diff, Step 4 alert. Stores currency alongside price. Falls back to apify/camoufox-scraper with residential proxy if Walmart blocks. Does NOT pick a generic web scraper or build a new Actor when an ecommerce-focused one exists.",
+    "type": "workflow:ecommerce-price-monitoring"
+  },
+  {
+    "prompt": "Track our Amazon listings for price drops or rating dips.",
+    "expected": "AMAZON PIPELINE. Step 1: apify/e-commerce-scraping-tool with startUrls (Amazon product URLs) + extractReviews. Step 2: compare vs stored baseline. Step 3: alert on price drop / rating drop. Always stores currency alongside price (Amazon rotates regional prices). For review text (not just counts), searches Store for a dedicated Actor (`apify actors search \"amazon reviews\"`).",
+    "type": "workflow:ecommerce-price-monitoring"
+  },
+  {
+    "prompt": "Pull new products from this supplier portal and create draft listings.",
+    "expected": "SUPPLIER CATALOG PIPELINE. Step 1: apify/playwright-scraper (JS portals) or apify/cheerio-scraper (static) with startUrls + pseudoUrls + maxCrawlPages. Step 2: apify/website-content-crawler optional second pass piping results[].url -> startUrls (maxCrawlPages=1, htmlTransformer='readableText'). Step 3: AI rewrites SEO title + bullets. Step 4: Shopify POST /products.json with status='draft'. For login-gated portals uses initialCookies / preNavigationHooks — never hardcodes credentials, passes via n8n credentials store.",
+    "type": "workflow:ecommerce-price-monitoring"
+  },
+  {
+    "prompt": "Detect when competitors run promotions or publish coupon codes.",
+    "expected": "DEALS & COUPONS PIPELINE. Step 1: apify/e-commerce-scraping-tool on deals/sale page URLs. Step 2 (fallback): apify/camoufox-scraper for failed JS-heavy URLs. Step 3: AI extracts discount %, promo code, expiry from raw text. Step 4: dedup vs stored deals + Slack alert. Notes: AI-extracted expiry dates are unreliable — treat as best-effort, not exact data.",
+    "type": "workflow:ecommerce-price-monitoring"
+  },
+  {
+    "prompt": "Evaluate this Instagram influencer's engagement quality.",
+    "expected": "INSTAGRAM CREATOR VETTING PIPELINE. Step 1: apify/instagram-profile-scraper with usernames. Step 2: apify/instagram-comment-scraper piping results[].latestPosts[].url -> directUrls (3-5 recent posts), with resultsLimit. Compares comment sentiment to post content — high followers + low-quality comments suggests fake followers.",
+    "type": "workflow:influencer-vetting"
+  },
+  {
+    "prompt": "Find this person's profiles across every social platform.",
+    "expected": "CROSS-PLATFORM INFLUENCER DISCOVERY. Single Actor: tri_angle/social-media-finder with query (name/handle) + platforms. Output: platform, profileUrl, username, followers, isVerified.",
+    "type": "workflow:influencer-vetting"
+  },
+  {
+    "prompt": "Vet these TikTok creators for partnership fit.",
+    "expected": "TIKTOK CREATOR VETTING PIPELINE. Step 1: clockworks/tiktok-profile-scraper with profiles + resultsPerPage. Step 2: clockworks/tiktok-video-scraper piping results[].authorMeta.name -> profiles, with maxItems. CALCULATES engagement rate manually: (diggCount + commentCount + shareCount) / playCount — the Actor does NOT return a pre-calculated ER.",
+    "type": "workflow:influencer-vetting"
+  },
+  {
+    "prompt": "Audit YouTube channels before sponsoring them.",
+    "expected": "YOUTUBE CHANNEL AUDIT PIPELINE. Step 1: streamers/youtube-channel-scraper with startUrls (channel URLs) + maxResults. Step 2: streamers/youtube-scraper piping results[].channelUrl -> startUrls. Step 3: curious_coder/youtube-transcript-scraper on 5-10 recent videos (results[].url) for theme analysis.",
+    "type": "workflow:influencer-vetting"
+  },
+  {
+    "prompt": "Find new influencer candidates by niche hashtags across IG, TikTok, and YouTube.",
+    "expected": "CROSS-PLATFORM HASHTAG DISCOVERY (PARALLEL). Runs three Actors in parallel with the same hashtags array: apify/instagram-hashtag-scraper, clockworks/tiktok-hashtag-scraper, streamers/youtube-video-scraper-by-hashtag. Then normalizes platform-specific fields into a common schema (username, platform, followersCount, avgEngagement, profileUrl) before scoring.",
+    "type": "workflow:influencer-vetting"
+  },
+  {
+    "prompt": "Research LinkedIn job postings for ML engineers in Berlin.",
+    "expected": "JOB LISTING PIPELINE. Step 1: harvestapi/linkedin-job-search with keyword + location + datePosted + limit. Step 2: apimaestro/linkedin-job-detail piping results[].jobUrl -> urls. Both PPE — Step 1 ~$0.001/job, Step 2 ~$0.005/job (~$1.20 for 200 jobs). Estimates + confirms with user.",
+    "type": "workflow:job-market-and-recruitment"
+  },
+  {
+    "prompt": "Source candidates with senior frontend engineering experience in NYC.",
+    "expected": "CANDIDATE SOURCING PIPELINE. Step 1: harvestapi/linkedin-profile-search with keyword + title + location + industry + limit. Step 2: apimaestro/linkedin-profile-full-sections-scraper piping results[].profileUrl -> urls. Uses Step 2 SPARINGLY (most expensive LinkedIn scraper, ~$0.01/profile) — shortlisted candidates only.",
+    "type": "workflow:job-market-and-recruitment"
+  },
+  {
+    "prompt": "Monitor companies hiring Head of Data Engineering as a buying signal.",
+    "expected": "JOB-AS-BUYING-SIGNAL PIPELINE. Step 1: harvestapi/linkedin-job-search with searchUrl (LinkedIn Jobs URL with company/role filters) + keywords. Step 2: harvestapi/linkedin-company piping results[].companyUrl -> companyUrls. Passes job description to an LLM to extract inferred tech stack and budget tier before prioritizing outreach. Contact-finding via Hunter.io is a native n8n node, NOT an Apify Actor.",
+    "type": "workflow:job-market-and-recruitment"
+  },
+  {
+    "prompt": "Monitor Upwork for new jobs matching my Python+ML skills.",
+    "expected": "UPWORK MONITORING. Single Actor: apify/playwright-scraper (Upwork is JS-heavy — basic HTTP fails) with startUrls (Upwork search URL with skill filters) + pseudoUrls + maxCrawledPages. First runs `apify actors search \"upwork\"` to check for community Actors before defaulting to playwright-scraper. Stores seen job URLs for high-frequency runs to dedupe.",
+    "type": "workflow:job-market-and-recruitment"
+  },
+  {
+    "prompt": "Find developers contributing to these open-source projects.",
+    "expected": "GITHUB CONTRIBUTOR DISCOVERY. Single Actor: janbuchar/github-contributors-scraper with repoUrls. Output: username, contributions, profileUrl, avatarUrl.",
+    "type": "workflow:job-market-and-recruitment"
+  },
+  {
+    "prompt": "Ingest this whole documentation site into our Supabase vector DB for our chatbot.",
+    "expected": "WEBSITE TO RAG PIPELINE. Step 1: apify/sitemap-extractor with sitemapUrl or domain. Step 2: apify/website-content-crawler piping results[].url -> startUrls (or dataset id), with maxCrawlPages + htmlTransformer='readableText' + outputFormats=['markdown']. Step 3: text splitter + OpenAI embeddings. Step 4: upsert to vector DB. Notes apify/rag-web-browser as a SIMPLER alternative when full-site coverage isn't needed.",
+    "type": "workflow:knowledge-base-and-rag"
+  },
+  {
+    "prompt": "AI agent: given a research question, generate queries, crawl results, write a report.",
+    "expected": "DEEP RESEARCH AGENT PIPELINE. Step 1: AI generates 3-5 search queries. Step 2: apify/google-search-scraper with the generated queries (maxResultsPerPage 5-10). Step 3: apify/rag-web-browser piping URLs -> query (RAG browser fetches+summarizes per call). Step 4: AI synthesis. Uses n8n Split In Batches with concurrency 3-5 for parallel URL processing (cuts runtime significantly vs sequential).",
+    "type": "workflow:knowledge-base-and-rag"
+  },
+  {
+    "prompt": "Daily news monitoring with AI summaries and a searchable knowledge base.",
+    "expected": "NEWS MONITORING PIPELINE. Step 1: lukaskrivka/article-extractor-smart with startUrls (news listing pages) + maxCrawlPages + articleSelector. Step 2: dedup by URL + filter new only. Step 3 (optional): apify/website-content-crawler piping new article urls -> startUrls when listing-page extract is too short. Step 4: AI summarize + tag. Step 5: upsert to Notion/NocoDB/Supabase. Drops sources whose text consistently comes back under 200 chars (paywalled).",
+    "type": "workflow:knowledge-base-and-rag"
+  },
+  {
+    "prompt": "Get me business contacts and emails for restaurants in Austin.",
+    "expected": "LOCAL BUSINESS LEADS PIPELINE. Step 1: compass/crawler-google-places with searchStringsArray + locationQuery + maxCrawledPlaces. Step 2: compass/enrich-google-maps-dataset-with-contacts, piping the Step-1 dataset id (or results[].url -> startUrls). Output includes emails[], phones[], socialLinks. Sets language='en' and a specific city locationQuery, not just a country.",
+    "type": "workflow:lead-generation"
+  },
+  {
+    "prompt": "Find me 200 product managers at fintechs in NYC with their emails.",
+    "expected": "B2B LINKEDIN DISCOVERY PIPELINE. Step 1: harvestapi/linkedin-profile-search with keyword/title/location/limit. Step 2: harvestapi/linkedin-profile-scraper, piping results[].profileUrl -> urls, with includeEmail: true. Flags both Actors as PPE and estimates cost (~$0.01/profile with email -> ~$2 for 200) and confirms with user before running.",
+    "type": "workflow:lead-generation"
+  },
+  {
+    "prompt": "Pull 1000 leads daily from a Sales Navigator saved search and verify emails.",
+    "expected": "SALES NAV BULK EXTRACTION PIPELINE. Step 1: harvestapi/linkedin-profile-search with searchUrl (the SAVED Sales Navigator URL), maxResults, proxy. Step 2: email verification via Hunter.io or ZeroBounce (NOT an Apify Actor — native node / HTTP). Flags PPE cost (~$5-10 for 1,000 leads), requires confirmation for scheduled daily runs, and notes the URL must be a SAVED search (one-time results URLs expire).",
+    "type": "workflow:lead-generation"
+  },
+  {
+    "prompt": "Find SaaS companies via Google, qualify against our ICP, and add to CRM.",
+    "expected": "SERP B2B DISCOVERY PIPELINE. Step 1: apify/google-search-scraper with queries/maxResultsPerPage/countryCode. Step 2: apify/website-content-crawler, piping results[].organicResults[].url -> startUrls (FILTERED to root domains, not blog post URLs), with maxCrawlDepth=2, maxCrawlPages=5. Plus an LLM qualification step against ICP. Does NOT pipe individual article URLs.",
+    "type": "workflow:lead-generation"
+  },
+  {
+    "prompt": "Generate personalized icebreaker emails for our Apollo lead list.",
+    "expected": "APOLLO + AI ICEBREAKERS PIPELINE. Step 1: apify/website-content-crawler with the Apollo lead company websites as startUrls, maxCrawlDepth=2, maxCrawlPages=5. Step 2: AI node (GPT-4o or Claude) piping results[].text + lead name + role into the icebreaker prompt. Filters Apollo export for http(s) URLs first — drops LinkedIn URLs (which block crawlers).",
+    "type": "workflow:lead-generation"
+  },
+  {
+    "prompt": "Find prospects on Reddit who are complaining about problems our product solves.",
+    "expected": "REDDIT LEAD MINING PIPELINE. Step 1: trudax/reddit-scraper-lite with startUrls (subreddit URLs) + searchTerms (problem keywords) + maxItems + sort. Step 2: AI qualification node piping results[].title + results[].body into the prompt. Notes Reddit usernames are pseudonymous (no email enrichment path) — output is intent signals + post URLs for DM outreach, not direct contacts.",
+    "type": "workflow:lead-generation"
+  },
+  {
+    "prompt": "Find 3-bedroom homes for sale in Austin under $700k.",
+    "expected": "PROPERTY SEARCH PIPELINE. Step 1: tri_angle/redfin-search with location + propertyType + minPrice + maxPrice. Step 2: tri_angle/redfin-detail piping results[].url -> startUrls. Output detail: yearBuilt, lotSize, priceHistory[], taxHistory[], schools[].",
+    "type": "workflow:real-estate-and-hospitality"
+  },
+  {
+    "prompt": "Analyze Airbnb listings and reviews in Lisbon for a week in June.",
+    "expected": "AIRBNB MARKET ANALYSIS PIPELINE. Step 1: tri_angle/new-fast-airbnb-scraper with location + checkIn + checkOut + maxItems (checkIn/checkOut are REQUIRED for accurate pricing — Airbnb prices vary by date). Step 2: tri_angle/airbnb-reviews-scraper piping results[].url -> startUrls. For seasonal analysis, runs multiple date ranges.",
+    "type": "workflow:real-estate-and-hospitality"
+  },
+  {
+    "prompt": "Qualify inbound real estate leads from the MLS portal and route to the right agent.",
+    "expected": "LEAD SCORING + ROUTING PIPELINE. Step 1: tri_angle/redfin-search with location + minPrice + maxPrice from the lead payload. Step 2 (OPTIONAL): harvestapi/linkedin-profile-scraper only when the lead's identity is known and a LinkedIn profile URL is available. Core hot/warm/cold routing runs on the MLS webhook payload; scraping is enrichment only. AI outputs leadTier + assignedAgent + routingReason.",
+    "type": "workflow:real-estate-and-hospitality"
+  },
+  {
+    "prompt": "Find new-construction or pre-market property listings before they hit Zillow.",
+    "expected": "PRE-MARKET DISCOVERY PIPELINE. Step 1: apify/playwright-scraper (JS-heavy portals required) with startUrls (local MLS / construction portal URLs) + proxyConfiguration. Step 2: lukaskrivka/article-extractor-smart piping results[].url -> urls (cleans into projectName/price/location/possessionDate/constructionStatus). First runs `apify actors search \"real estate\"` to check for community Actors before defaulting to playwright-scraper.",
+    "type": "workflow:real-estate-and-hospitality"
+  },
+  {
+    "prompt": "Compare listings across Zillow, Realtor, Zumper, and Apartments.com.",
+    "expected": "MULTI-SOURCE PROPERTY COMPARISON. Single Actor: tri_angle/real-estate-aggregator with location + propertyType + sources (Zillow, Realtor, Zumper, Apartments.com, Rightmove). Output normalized: address, price, beds, baths, sqft, source, url, listingDate.",
+    "type": "workflow:real-estate-and-hospitality"
+  },
+  {
+    "prompt": "Collect Google Maps reviews for the top coffee shops in Portland.",
+    "expected": "GOOGLE MAPS REVIEWS PIPELINE. Step 1: compass/crawler-google-places with searchStringsArray + locationQuery + maxCrawledPlaces. Step 2: compass/Google-Maps-Reviews-Scraper, piping results[].url -> startUrls, with maxReviews. Output includes text, stars, publishedAtDate, reviewerName, ownerResponse.",
+    "type": "workflow:review-analysis"
+  },
+  {
+    "prompt": "Compare competitor reviews to find their customer pain points.",
+    "expected": "COMPETITOR REVIEW INTELLIGENCE PIPELINE. Step 1: compass/Google-Maps-Reviews-Scraper on competitor Google Maps URLs (startUrls, maxReviews, sort). Step 2: tri_angle/yelp-review-scraper on competitor Yelp URLs IN PARALLEL with Step 1, then merge by date. Labels each review with the competitor name before AI theme extraction.",
+    "type": "workflow:review-analysis"
+  },
+  {
+    "prompt": "Alert me daily when an app gets low-rating Google Play reviews.",
+    "expected": "GOOGLE PLAY REVIEW MONITORING PIPELINE. Step 1: apify/playwright-scraper (NOT cheerio — Google Play is heavy client-side rendering) with the Google Play app URL as startUrls. Step 2: filter where stars < 4 (n8n IF node). Suggests checking the Store for a dedicated Google Play reviews Actor if results are thin (`apify actors search ...`).",
+    "type": "workflow:review-analysis"
+  },
+  {
+    "prompt": "Get reviews across TripAdvisor, Yelp, Google, and Booking for one hotel.",
+    "expected": "HOTEL CROSS-PLATFORM REVIEWS. Single Actor: tri_angle/hotel-review-aggregator with urls (per-platform property URLs). Output includes text, rating, date, platform, reviewerName, title. For restaurants the analog is tri_angle/restaurant-review-aggregator.",
+    "type": "workflow:review-analysis"
+  },
+  {
+    "prompt": "Weekly sentiment digest for this hotel across all major sites including Airbnb.",
+    "expected": "HOSPITALITY MULTI-PLATFORM PIPELINE. Step 1: tri_angle/hotel-review-aggregator with property page URLs (startUrls, maxReviews, includeReviews). Step 2: tri_angle/airbnb-reviews-scraper SEPARATELY for Airbnb listings, then merge by date. Recommends the aggregator over per-platform scrapers when covering 3+ platforms (cheaper). Theme extraction by category (service/rooms/location/price) suggested.",
+    "type": "workflow:review-analysis"
+  },
+  {
+    "prompt": "Get Yelp reviews for sushi restaurants in San Francisco.",
+    "expected": "YELP REVIEW PIPELINE. Step 1: tri_angle/get-yelp-urls with location + category. Step 2: tri_angle/yelp-review-scraper, piping results[].url -> startUrls, with maxReviews. Output: text, rating, date, userName.",
+    "type": "workflow:review-analysis"
+  },
+  {
+    "prompt": "Engagement metrics and content performance for this Instagram account.",
+    "expected": "IG ACCOUNT PERFORMANCE PIPELINE. Step 1: apify/instagram-profile-scraper with usernames. Step 2: apify/instagram-post-scraper with directUrls (from profile's latestPosts[].url) or usernames. Output: followersCount, engagement metrics per post.",
+    "type": "workflow:social-media-analytics"
+  },
+  {
+    "prompt": "Performance data for this TikTok creator.",
+    "expected": "TIKTOK CREATOR ANALYTICS. Single Actor: clockworks/tiktok-profile-scraper with profiles (handles or URLs). Output: followers, following, likes, videos, recentVideos[] with per-video views/likes/shares.",
+    "type": "workflow:social-media-analytics"
+  },
+  {
+    "prompt": "What content formats are winning for our competitors on Instagram?",
+    "expected": "IG COMPETITOR CONTENT PIPELINE. Step 1: apify/instagram-post-scraper with usernames (competitor handles) + resultsLimit (100) + scrapePostsUntilDate. Step 2: apify/instagram-reel-scraper with the SAME usernames. RUNS BOTH (post scraper may under-count reels). Computes engagement rate = (likes + comments) / followers and sorts to surface top performers.",
+    "type": "workflow:social-media-analytics"
+  },
+  {
+    "prompt": "Track our LinkedIn company page post performance vs competitors.",
+    "expected": "LINKEDIN COMPANY ANALYTICS PIPELINE. Step 1: harvestapi/linkedin-company-posts with companyUrl + maxPosts + publishedAfter. Step 2: apimaestro/linkedin-post-detail piping results[].url -> urls. Both PPE; ~$2.10 for 100 posts × 3 companies. Confirms before running.",
+    "type": "workflow:social-media-analytics"
+  },
+  {
+    "prompt": "Compare one account's performance across IG, TikTok, YouTube, and Twitter.",
+    "expected": "MULTI-PLATFORM ENGAGEMENT (PARALLEL). Runs FOUR Actors independently: apify/instagram-profile-scraper (usernames), clockworks/tiktok-profile-scraper (profiles), streamers/youtube-channel-scraper (channelUrls), apidojo/twitter-user-scraper (handles). NORMALIZES metric names (followers/subscribers, posts/videos/tweets) before comparing.",
+    "type": "workflow:social-media-analytics"
+  },
+  {
+    "prompt": "How is search demand for \"vector database\" trending in the US?",
+    "expected": "GOOGLE TRENDS. Single Actor: apify/google-trends-scraper with searchTerms + timeRange + geo (country code). Output: term, timelineData[] (date,value), relatedQueries[], relatedTopics[].",
+    "type": "workflow:trend-research"
+  },
+  {
+    "prompt": "How big is this hashtag across IG, TikTok, YouTube, and Facebook?",
+    "expected": "CROSS-PLATFORM HASHTAG RESEARCH. Single Actor: apify/social-media-hashtag-research with hashtags + platforms (instagram, youtube, tiktok, facebook). Output: hashtag, platform, postsCount, topPosts[], relatedHashtags[].",
+    "type": "workflow:trend-research"
+  },
+  {
+    "prompt": "What's trending on TikTok right now?",
+    "expected": "TIKTOK TREND DISCOVERY PIPELINE. Step 1: clockworks/tiktok-trends-scraper with channel (trending category). Step 2: clockworks/tiktok-explore-scraper with exploreCategories. Output: trending videos + categories with authors/music.",
+    "type": "workflow:trend-research"
+  },
+  {
+    "prompt": "Surface emerging trends and competitor mentions from these subreddits weekly.",
+    "expected": "REDDIT TREND MINING. Single Actor: trudax/reddit-scraper-lite with startUrls + maxItems + sort. Uses sort='rising' for EARLY trend signals, sort='hot' for CONFIRMED trending — does not mix. Filters by score threshold (e.g. >50) to reduce noise.",
+    "type": "workflow:trend-research"
+  },
+  {
+    "prompt": "Find breakout videos in our niche — small channels with big-view outliers.",
+    "expected": "YOUTUBE OUTLIER DISCOVERY PIPELINE. Step 1: streamers/youtube-scraper with searchTerms + maxResults + sort='viewCount' + uploadDate filter. Step 2: streamers/youtube-channel-scraper piping results[].channelUrl -> channelUrls (FILTERED shortlist only — no need to fetch channel data for every result). Outlier score = video viewCount / channel subscriberCount; ratios >10x indicate breakout.",
+    "type": "workflow:trend-research"
+  },
+  {
+    "prompt": "Validate whether this content topic actually has audience demand.",
+    "expected": "CONTENT TOPIC VALIDATION PIPELINE. Step 1: apify/google-trends-scraper with searchTerms (topic keywords). Step 2: apify/social-media-hashtag-research with hashtags (topic hashtags). Combines BOTH because Google Trends shows RELATIVE interest (0-100), not absolute volume — hashtag post counts give the absolute side.",
+    "type": "workflow:trend-research"
+  }
+]

--- a/evals/apify-ultimate-scraper.json
+++ b/evals/apify-ultimate-scraper.json
@@ -10,11 +10,6 @@
     "type": "selection"
   },
   {
-    "prompt": "From the search results, what's the Actor ID I should use?",
-    "expected": "ACTOR ID CONSTRUCTION. Builds the Actor ID by concatenating `{items[].username}/{items[].name}` (e.g. `apify/instagram-scraper`, `compass/crawler-google-places`, `clockworks/tiktok-scraper`). Does NOT fabricate IDs from memory (e.g. assuming `apify/google-maps-scraper` when the real top result is `compass/crawler-google-places`). Treats `username` and `name` as two separate JSON fields that must both be read.",
-    "type": "selection"
-  },
-  {
     "prompt": "I need LinkedIn lead-generation data: companies, employees, and emails.",
     "expected": "WORKFLOW RECOGNITION. Recognizes this matches the 'leads, contacts, emails, B2B' row in the Step 1 workflow trigger table, and additionally loads references/workflows/lead-generation.md before picking Actors. Does NOT pick a single LinkedIn Actor in isolation when a multi-step pipeline guide exists for the use case.",
     "type": "selection"
@@ -30,59 +25,14 @@
     "type": "selection"
   },
   {
-    "prompt": "I picked apify/instagram-scraper. Let's go.",
-    "expected": "SCHEMA BEFORE RUN. Fetches the input schema with `apify actors info \"apify/instagram-scraper\" --user-agent apify-agent-skills/apify-ultimate-scraper --input --json 2>/dev/null` to learn the correct input field names BEFORE constructing input. Does not invent input fields from memory.",
-    "type": "schema-and-gotchas"
-  },
-  {
-    "prompt": "Use this scraper to pull 500 Instagram posts.",
-    "expected": "GOTCHAS CHECK. Reads references/gotchas.md before running and applies relevant pitfalls — for Instagram specifically: keep maxResults under 200 per run (platform rate-limit guidance), expect platform-blocking without proxy, and verify field names with `--input --json` (some Actors use `resultsLimit`, others `maxItems`, others `maxResults`).",
-    "type": "schema-and-gotchas"
-  },
-  {
-    "prompt": "I'm getting empty results from this social-media Actor and I know the account exists.",
-    "expected": "COOKIE/AUTH DIAGNOSIS. Recognizes social-media scrapers commonly need cookies/login. Checks the Actor README (`apify actors info \"ACTOR_ID\" --user-agent apify-agent-skills/apify-ultimate-scraper --readme`) for mentions of `cookies`, `login`, `session`, or `proxy`. Suggests enabling Apify Proxy or providing session cookies if required. Does NOT assume the account doesn't exist.",
-    "type": "schema-and-gotchas"
-  },
-  {
-    "prompt": "How do I limit this to just 100 items? I tried `maxResults: 100` but it ignored me.",
-    "expected": "FIELD NAME VARIANCE. Explains that limit field names vary by Actor — common variants include `maxResults`, `resultsLimit`, `maxItems` (output items) vs `maxCrawledPages`, `maxRequestsPerCrawl` (pages visited). Tells the user to fetch the input schema with `--input --json` to find the correct field for THIS Actor, rather than guessing.",
-    "type": "schema-and-gotchas"
-  },
-  {
     "prompt": "What's Nike's follower count on Instagram?",
     "expected": "QUICK-ANSWER MODE. Treats this as a simple lookup: skips user-preference questions, runs the Actor in quick-answer mode (blocking `apify actors call ... --json`), and presents the single answer in chat. Does not prompt for output format / result count for a trivial lookup.",
-    "type": "run"
-  },
-  {
-    "prompt": "Run a large scrape that will take a while and let me check on it later.",
-    "expected": "ASYNC RUN. Uses `apify actors start \"ACTOR_ID\" -i '<json>' --user-agent apify-agent-skills/apify-ultimate-scraper --json 2>/dev/null` (fire-and-forget) and polls with `apify runs info RUN_ID --user-agent apify-agent-skills/apify-ultimate-scraper --json 2>/dev/null` checking .status for SUCCEEDED, rather than a blocking call that could time out.",
-    "type": "run"
-  },
-  {
-    "prompt": "Give me the results as a CSV file.",
-    "expected": "RETRIEVE + SAVE. Fetches results with `apify datasets get-items DATASET_ID --user-agent apify-agent-skills/apify-ultimate-scraper --format csv` and saves via the Write tool to a dated filename of the form `YYYY-MM-DD_descriptive-name.csv`. For JSON, uses --format json.",
-    "type": "run"
-  },
-  {
-    "prompt": "Okay, the run finished — wrap it up for me.",
-    "expected": "DELIVER. Reports result count, file location (if saved), key data fields, and BOTH console links: dataset (https://console.apify.com/storage/datasets/DATASET_ID) AND run (https://console.apify.com/actors/runs/RUN_ID). For multi-step workflows, suggests the next pipeline step from the workflow guide.",
     "type": "run"
   },
   {
     "prompt": "Search the store for a Yelp review scraper and show me options.",
     "expected": "CLI CONVENTIONS. Follows the skill's mandatory command rules: passes `--json`, includes `--user-agent apify-agent-skills/apify-ultimate-scraper`, and redirects stderr with `2>/dev/null` so JSON parses cleanly. Applies these THREE rules to every apify command, not just search.",
     "type": "run"
-  },
-  {
-    "prompt": "Scrape 2,000 results from this pay-per-event Actor.",
-    "expected": "PPE COST GATE + DISCLAIMER. Before running, reads .currentPricingInfo.pricePerEvent from `apify actors info`, multiplies by the requested count, and presents an estimate WITH the rough-estimate disclaimer language (mentions estimate-only, actual costs may vary with Actor/data/retries/platform changes, refers user to Apify billing dashboard for actual charges). Does not silently launch a paid run.",
-    "type": "cost"
-  },
-  {
-    "prompt": "Run this PPE Actor for 50,000 items.",
-    "expected": "HIGH-COST CONFIRMATION. Produces a cost estimate; since a large PPE run will exceed the thresholds, explicitly warns (>$5) and REQUIRES explicit user confirmation before proceeding (>$20). Suggests batching.",
-    "type": "cost"
   },
   {
     "prompt": "I need to scrape LinkedIn profiles in bulk with emails.",

--- a/evals/apify-ultimate-scraper.json
+++ b/evals/apify-ultimate-scraper.json
@@ -25,6 +25,26 @@
     "type": "selection"
   },
   {
+    "prompt": "I want to use apify/instagram-scraper. What should I do before constructing the run input?",
+    "expected": "SCHEMA BEFORE RUN. Fetches the input schema with apify actors info \"apify/instagram-scraper\" --user-agent apify-agent-skills/apify-ultimate-scraper --input --json 2>/dev/null to learn the correct input field names BEFORE constructing input. Does not invent input fields from memory.",
+    "type": "schema-and-gotchas"
+  },
+  {
+    "prompt": "Use apify/instagram-post-scraper to pull 500 posts from one account. What should I check first?",
+    "expected": "GOTCHAS CHECK. Reads references/gotchas.md before running and applies relevant pitfalls — for Instagram specifically: keep maxResults under 200 per run (platform rate-limit guidance), expect platform-blocking without proxy, and verify field names with --input --json (some Actors use resultsLimit, others maxItems, others maxResults).",
+    "type": "schema-and-gotchas"
+  },
+  {
+    "prompt": "I called apify/instagram-profile-scraper for a known-active account and got empty results. Whats likely wrong?",
+    "expected": "COOKIE/AUTH DIAGNOSIS. Recognizes social-media scrapers commonly need cookies/login. Checks the Actor README (apify actors info \"ACTOR_ID\" --user-agent apify-agent-skills/apify-ultimate-scraper --readme) for mentions of cookies, login, session, or proxy. Suggests enabling Apify Proxy or providing session cookies if required. Does NOT assume the account does not exist.",
+    "type": "schema-and-gotchas"
+  },
+  {
+    "prompt": "Im running apify/website-content-crawler and tried passing maxResults: 100 to cap output, but it returned more. Why?",
+    "expected": "FIELD NAME VARIANCE. Explains that limit field names vary by Actor — common variants include maxResults, resultsLimit, maxItems (output items) vs maxCrawledPages, maxRequestsPerCrawl (pages visited). Tells the user to fetch the input schema with --input --json to find the correct field for THIS Actor, rather than guessing.",
+    "type": "schema-and-gotchas"
+  },
+  {
     "prompt": "What's Nike's follower count on Instagram?",
     "expected": "QUICK-ANSWER MODE. Treats this as a simple lookup: skips user-preference questions, runs the Actor in quick-answer mode (blocking `apify actors call ... --json`), and presents the single answer in chat. Does not prompt for output format / result count for a trivial lookup.",
     "type": "run"
@@ -32,6 +52,21 @@
   {
     "prompt": "Search the store for a Yelp review scraper and show me options.",
     "expected": "CLI CONVENTIONS. Follows the skill's mandatory command rules: passes `--json`, includes `--user-agent apify-agent-skills/apify-ultimate-scraper`, and redirects stderr with `2>/dev/null` so JSON parses cleanly. Applies these THREE rules to every apify command, not just search.",
+    "type": "run"
+  },
+  {
+    "prompt": "I want to run apify/website-content-crawler over ~5000 pages — expect 30+ minutes. How do I kick it off and check status later instead of blocking?",
+    "expected": "ASYNC RUN. Uses apify actors start \"ACTOR_ID\" -i '<json>' --user-agent apify-agent-skills/apify-ultimate-scraper --json 2>/dev/null (fire-and-forget) and polls with apify runs info RUN_ID --user-agent apify-agent-skills/apify-ultimate-scraper --json 2>/dev/null checking .status for SUCCEEDED, rather than a blocking call that could time out.",
+    "type": "run"
+  },
+  {
+    "prompt": "I have a finished Apify run with dataset id DATASET_ID. How do I save the results to a CSV file?",
+    "expected": "RETRIEVE + SAVE. Fetches results with apify datasets get-items DATASET_ID --user-agent apify-agent-skills/apify-ultimate-scraper --format csv and saves via the Write tool to a dated filename of the form YYYY-MM-DD_descriptive-name.csv. For JSON, uses --format json.",
+    "type": "run"
+  },
+  {
+    "prompt": "My apify/instagram-scraper run just finished with run id RUN_ID. How should I report the results to the user?",
+    "expected": "DELIVER. Reports result count, file location (if saved), key data fields, and BOTH console links: dataset (https://console.apify.com/storage/datasets/DATASET_ID) AND run (https://console.apify.com/actors/runs/RUN_ID). For multi-step workflows, suggests the next pipeline step from the workflow guide.",
     "type": "run"
   },
   {
@@ -47,6 +82,16 @@
   {
     "prompt": "This Actor's pricingModel is FLAT_PRICE_PER_MONTH. Can I just run it?",
     "expected": "FLAT_PRICE SUBSCRIPTION CHECK. Recognizes FLAT_PRICE_PER_MONTH requires a monthly subscription, and verifies (or asks the user to verify) that they have an active subscription before attempting to run. Distinguishes from FREE (just run) and PAY_PER_EVENT (estimate first).",
+    "type": "cost"
+  },
+  {
+    "prompt": "I want 2,000 results from junglee/Amazon-crawler (PAY_PER_EVENT). What should happen before I run it?",
+    "expected": "PPE COST GATE + DISCLAIMER. Before running, reads .currentPricingInfo.pricePerEvent from apify actors info, multiplies by the requested count, and presents an estimate WITH the rough-estimate disclaimer language (mentions estimate-only, actual costs may vary with Actor/data/retries/platform changes, refers user to Apify billing dashboard for actual charges). Does not silently launch a paid run.",
+    "type": "cost"
+  },
+  {
+    "prompt": "I want to run harvestapi/linkedin-profile-scraper (PAY_PER_EVENT) for 50,000 profiles. What should happen first?",
+    "expected": "HIGH-COST CONFIRMATION. Produces a cost estimate; since a large PPE run will exceed the thresholds, explicitly warns (>$5) and REQUIRES explicit user confirmation before proceeding (>$20). Suggests batching.",
     "type": "cost"
   },
   {

--- a/evals/routing.json
+++ b/evals/routing.json
@@ -1,0 +1,68 @@
+[
+  {
+    "prompt": "Add web scraping to my Express app by calling Apify Actors from the backend.",
+    "expected_skill": "apify-sdk-integration",
+    "acceptable_skills": [],
+    "rationale": "Calling Actors from existing app code = apify-client integration. Disambiguates from ultimate-scraper (direct scraping) and actor-development (authoring Actors)."
+  },
+  {
+    "prompt": "Scrape the follower lists of these 50 Instagram accounts and give me a CSV.",
+    "expected_skill": "apify-ultimate-scraper",
+    "acceptable_skills": [
+      "apify-sdk-integration"
+    ],
+    "rationale": "A direct, one-off platform-scraping task with a deliverable = ultimate-scraper. sdk-integration is defensible if framed as app code, hence soft-acceptable."
+  },
+  {
+    "prompt": "Build a brand-new Apify Actor that scrapes a niche site with no existing Actor.",
+    "expected_skill": "apify-actor-development",
+    "acceptable_skills": [],
+    "rationale": "Authoring a new Actor from scratch. Disambiguates from actorization (converting an EXISTING project)."
+  },
+  {
+    "prompt": "I have a working Node.js scraper repo. Turn it into an Apify Actor.",
+    "expected_skill": "apify-actorization",
+    "acceptable_skills": [
+      "apify-actor-development"
+    ],
+    "rationale": "Converting an existing project = actorization. The overlap with actor-development is the key thing this eval probes."
+  },
+  {
+    "prompt": "Generate the dataset and output schemas for my Actor by reading its source.",
+    "expected_skill": "apify-generate-output-schema",
+    "acceptable_skills": [],
+    "rationale": "Narrow, specific task. Disambiguates from actor-development, which also touches schemas but is broader."
+  },
+  {
+    "prompt": "My Actor throws an error on apify push and the run fails. Help me debug.",
+    "expected_skill": "apify-actor-development",
+    "acceptable_skills": [],
+    "rationale": "Debugging/deploying existing Actor code = actor-development ('modifying existing ones, troubleshooting')."
+  },
+  {
+    "prompt": "I need LinkedIn lead-generation data: companies, employees, and emails.",
+    "expected_skill": "apify-ultimate-scraper",
+    "acceptable_skills": [],
+    "rationale": "Business use-case scraping across a covered platform = ultimate-scraper (explicitly lists lead generation)."
+  },
+  {
+    "prompt": "Call apify/instagram-scraper from my Python service and store the results in our DB.",
+    "expected_skill": "apify-sdk-integration",
+    "acceptable_skills": [],
+    "rationale": "Programmatic call + persistence inside an app = apify-client integration."
+  },
+  {
+    "prompt": "Build a tool that checks Amazon and Walmart and finds better deals.",
+    "expected_skill": "apify-sdk-integration",
+    "acceptable_skills": [
+      "apify-ultimate-scraper"
+    ],
+    "rationale": "Boundary case: the scraping is existing Actors, the 'better deals' logic is app code -> integration. ultimate-scraper acceptable if read as pure data extraction. Tests the build-vs-integrate-vs-scrape ambiguity."
+  },
+  {
+    "prompt": "Wrap my Python CLI tool so it runs on the Apify platform.",
+    "expected_skill": "apify-actorization",
+    "acceptable_skills": [],
+    "rationale": "CLI-wrapper migration is explicitly an actorization use case."
+  }
+]

--- a/skills/apify-actor-development/SKILL.md
+++ b/skills/apify-actor-development/SKILL.md
@@ -63,6 +63,8 @@ If browser login isn't available (headless environment or CI), the CLI automatic
 
 Use the appropriate CLI command based on the user's language choice. Additional packages (Crawlee, Playwright, etc.) can be installed later as needed.
 
+**For other templates (Crawlee + Cheerio, Playwright, Camoufox, etc.):** the `-t` value is the manifest's **`name`** field, not the `id` field. Look up the `name` here: https://raw.githubusercontent.com/apify/actor-templates/master/templates/manifest.json
+
 ## Quick start workflow
 
 1. **Create Actor project** - Run the appropriate `apify create` command based on user's language preference (see Template selection above)

--- a/skills/apify-sdk-integration/SKILL.md
+++ b/skills/apify-sdk-integration/SKILL.md
@@ -197,7 +197,7 @@ Full API reference: https://docs.apify.com/api/v2
 ## Best Practices
 
 - **Set timeouts:** Pass `timeoutSecs` in the Actor input or use `waitSecs` on `.call()` to avoid indefinite waits.
-- **Paginate large datasets:** Don't pull large datasets in one read — pass `limit`/`offset`, or write to a file and process in chunks. (`listItems()` returns all items by default.)
+- **Paginate large datasets:** Use `limit` and `offset` when retrieving dataset items. Default limit is 250K items.
 - **Reuse clients:** Create one `ApifyClient` instance and reuse it across calls.
 - **Handle Actor-specific input:** Every Actor has its own input schema. Use `fetch-actor-details` MCP tool or append `.md` to the Actor's Store URL to get the schema before constructing input.
 

--- a/skills/apify-sdk-integration/SKILL.md
+++ b/skills/apify-sdk-integration/SKILL.md
@@ -35,6 +35,8 @@ Before writing integration code, find the Actor that fits the user's needs. Use 
 
 Alternatively, browse https://apify.com/store. Append `.md` to any Actor's Store URL to get its docs in markdown.
 
+Actor IDs have the form `username/actor-name` (e.g. `apify/instagram-scraper`, `compass/crawler-google-places`) — take them from the search results, don't guess them from memory.
+
 ## JavaScript / TypeScript
 
 ### Install
@@ -195,7 +197,7 @@ Full API reference: https://docs.apify.com/api/v2
 ## Best Practices
 
 - **Set timeouts:** Pass `timeoutSecs` in the Actor input or use `waitSecs` on `.call()` to avoid indefinite waits.
-- **Paginate large datasets:** Use `limit` and `offset` when retrieving dataset items. Default limit is 250K items.
+- **Paginate large datasets:** Use `limit` and `offset` when retrieving dataset items. By default all items are returned — paginate explicitly for large datasets to bound memory and latency.
 - **Reuse clients:** Create one `ApifyClient` instance and reuse it across calls.
 - **Handle Actor-specific input:** Every Actor has its own input schema. Use `fetch-actor-details` MCP tool or append `.md` to the Actor's Store URL to get the schema before constructing input.
 

--- a/skills/apify-sdk-integration/SKILL.md
+++ b/skills/apify-sdk-integration/SKILL.md
@@ -197,7 +197,7 @@ Full API reference: https://docs.apify.com/api/v2
 ## Best Practices
 
 - **Set timeouts:** Pass `timeoutSecs` in the Actor input or use `waitSecs` on `.call()` to avoid indefinite waits.
-- **Paginate large datasets:** Use `limit` and `offset` when retrieving dataset items. By default all items are returned — paginate explicitly for large datasets to bound memory and latency.
+- **Paginate large datasets:** Don't pull large datasets in one read — pass `limit`/`offset`, or write to a file and process in chunks. (`listItems()` returns all items by default.)
 - **Reuse clients:** Create one `ApifyClient` instance and reuse it across calls.
 - **Handle Actor-specific input:** Every Actor has its own input schema. Use `fetch-actor-details` MCP tool or append `.md` to the Actor's Store URL to get the schema before constructing input.
 

--- a/skills/apify-sdk-integration/SKILL.md
+++ b/skills/apify-sdk-integration/SKILL.md
@@ -14,6 +14,8 @@ Add Apify Actor execution to an existing application. This skill covers the `api
 - Building a product that uses Apify as a backend service
 - Integrating Actor results into a data pipeline
 
+**Not for one-off scrapes.** If the goal is just to run an Actor and get or show the data (no app being built), use the Apify CLI via the `apify-ultimate-scraper` skill instead — don't pull in `apify-client`.
+
 ## Critical: Package Naming
 
 > **`apify-client`** is the API client for **calling** Actors from your app.
@@ -199,7 +201,7 @@ Full API reference: https://docs.apify.com/api/v2
 - **Set timeouts:** Pass `timeoutSecs` in the Actor input or use `waitSecs` on `.call()` to avoid indefinite waits.
 - **Paginate large datasets:** Use `limit` and `offset` when retrieving dataset items. Default limit is 250K items.
 - **Reuse clients:** Create one `ApifyClient` instance and reuse it across calls.
-- **Handle Actor-specific input:** Every Actor has its own input schema. Use `fetch-actor-details` MCP tool or append `.md` to the Actor's Store URL to get the schema before constructing input.
+- **Get an Actor's input schema before constructing input.** Reliable in any environment: run the CLI — `apify actors info "ID" --input` — which prints the schema (`title`, `description`, `properties`, `required`). (MCP `fetch-actor-details` or the Store URL `.md` work too, when available.) **Do not** read it off `client.actor(id).get()` — the Actor object does **not** include the input schema.
 
 ## Documentation
 

--- a/skills/apify-ultimate-scraper/SKILL.md
+++ b/skills/apify-ultimate-scraper/SKILL.md
@@ -58,6 +58,8 @@ If no Actor matches in the index, search dynamically:
 
 From results: `items[].username`/`items[].name` (Actor ID), `items[].title`, `items[].stats.totalUsers30Days`, `items[].currentPricingInfo.pricingModel`.
 
+If dynamic search also returns nothing suitable, fall back to a generic crawler picked by the target site's rendering: `apify/cheerio-scraper` for static HTML, `apify/playwright-scraper` for JS-rendered sites, `apify/camoufox-scraper` for anti-bot/WAF-protected sites (see `references/gotchas.md`).
+
 ### Step 2: Fetch Actor schema and check gotchas
 
 Fetch the input schema dynamically:
@@ -67,6 +69,8 @@ Fetch the input schema dynamically:
 Also read `references/gotchas.md` to check for common pitfalls for the selected Actor.
 
 For Actor documentation: `apify actors info "ACTOR_ID" --user-agent apify-agent-skills/apify-ultimate-scraper --readme`
+
+**Exception for quick-answer lookups (see Step 3):** when the input shape is obvious (e.g., a username for a profile scraper) and the Actor is from the curated index, you may skip the schema fetch and use minimal input. Still check pricing if the Actor is PPE.
 
 ### Step 3: Configure and run
 

--- a/skills/apify-ultimate-scraper/SKILL.md
+++ b/skills/apify-ultimate-scraper/SKILL.md
@@ -11,6 +11,7 @@ AI-driven data extraction from ~100 Actors across 15+ platforms via the Apify CL
 1. Pass `--json` for machine-readable output (stable across CLI versions).
 2. Pass `--user-agent apify-agent-skills/apify-ultimate-scraper` for telemetry attribution.
 3. Redirect stderr with `2>/dev/null` (stderr contains progress messages that break JSON parsers).
+4. Parse CLI `--json` output **as-is** — it is unwrapped. Fields sit at the top level (`items`, `.id`, `.status`); there is no `data` envelope. The `{ "data": { … } }` wrapper exists only on the `api.apify.com/v2` REST API, never on the CLI.
 
 ## Prerequisites
 
@@ -56,7 +57,15 @@ If no Actor matches in the index, search dynamically:
 
     apify actors search "KEYWORDS" --user-agent apify-agent-skills/apify-ultimate-scraper --json --limit 10 2>/dev/null
 
-From results: `items[].username`/`items[].name` (Actor ID), `items[].title`, `items[].stats.totalUsers30Days`, `items[].currentPricingInfo.pricingModel`.
+The CLI prints the result object **unwrapped** — the array is at the top level under `items`, with no `data` envelope (that envelope only exists on the `api.apify.com/v2` REST API, *not* the CLI). Shape:
+
+    { "total": 3863, "count": 10, "offset": 0, "limit": 10,
+      "items": [ { "username": "compass", "name": "crawler-google-places",
+                   "title": "Google Maps Scraper",
+                   "stats": { "totalUsers30Days": 28930 },
+                   "currentPricingInfo": { "pricingModel": "PAY_PER_EVENT" } } ] }
+
+From results: `items[].username`/`items[].name` (Actor ID), `items[].title`, `items[].stats.totalUsers30Days`, `items[].currentPricingInfo.pricingModel`. Parse `items` directly (e.g. `obj.items`) — **not** `obj.data.items`.
 
 If dynamic search also returns nothing suitable, fall back to a generic crawler picked by the target site's rendering: `apify/cheerio-scraper` for static HTML, `apify/playwright-scraper` for JS-rendered sites, `apify/camoufox-scraper` for anti-bot/WAF-protected sites (see `references/gotchas.md`).
 

--- a/skills/apify-ultimate-scraper/SKILL.md
+++ b/skills/apify-ultimate-scraper/SKILL.md
@@ -13,7 +13,7 @@ Treat what you remember about Apify as outdated until you verify it. Actor IDs, 
 **Rules for every `apify` command:**
 1. Pass `--json` for machine-readable output (stable across CLI versions). **Exception:** `apify actors info … --input` — omit `--json` there, or it returns the whole Actor object instead of the input schema (see Step 2).
 2. Pass `--user-agent apify-agent-skills/apify-ultimate-scraper` for telemetry attribution.
-3. Redirect stderr with `2>/dev/null` (stderr contains progress messages that break JSON parsers).
+3. Redirect stderr with `2>/dev/null` (stderr contains progress messages that break JSON parsers). **But if a command returns empty or unexpected output, re-run it WITHOUT `2>/dev/null` and read the error before changing approach** — the CLI's errors are specific and usually tell you the fix. Never switch tools (CLI → `apify-client` → hand-rolled scraping) because of a failure whose cause you haven't actually seen.
 4. Parse CLI `--json` output **as-is** — it is unwrapped. Fields sit at the top level (`items`, `.id`, `.status`); there is no `data` envelope. The `{ "data": { … } }` wrapper exists only on the `api.apify.com/v2` REST API, never on the CLI.
 
 ## Prerequisites
@@ -93,6 +93,8 @@ For larger tasks, confirm output format (quick answer / CSV / JSON) and result c
 **Standard run (blocking):**
 
     apify actors call "ACTOR_ID" -i 'JSON_INPUT' --user-agent apify-agent-skills/apify-ultimate-scraper --json 2>/dev/null
+
+`-i` takes **inline JSON only**. To pass input from a file, use `--input-file=PATH` (or `-f`) — **not** `-i @PATH` (the `@file` curl convention is rejected: *"Providing a JSON file path in the --input flag is not supported"*).
 
 From output: `.id` (run ID), `.status`, `.defaultDatasetId`, `.stats.durationMillis`
 

--- a/skills/apify-ultimate-scraper/SKILL.md
+++ b/skills/apify-ultimate-scraper/SKILL.md
@@ -66,11 +66,11 @@ Fetch the input schema dynamically:
 
     apify actors info "ACTOR_ID" --user-agent apify-agent-skills/apify-ultimate-scraper --input --json 2>/dev/null
 
+For trivial inputs (e.g., a single username for a profile scraper), this can be skipped — but still check pricing if the Actor is PPE.
+
 Also read `references/gotchas.md` to check for common pitfalls for the selected Actor.
 
 For Actor documentation: `apify actors info "ACTOR_ID" --user-agent apify-agent-skills/apify-ultimate-scraper --readme`
-
-**Exception for quick-answer lookups (see Step 3):** when the input shape is obvious (e.g., a username for a profile scraper) and the Actor is from the curated index, you may skip the schema fetch and use minimal input. Still check pricing if the Actor is PPE.
 
 ### Step 3: Configure and run
 

--- a/skills/apify-ultimate-scraper/SKILL.md
+++ b/skills/apify-ultimate-scraper/SKILL.md
@@ -62,11 +62,9 @@ If dynamic search also returns nothing suitable, fall back to a generic crawler 
 
 ### Step 2: Fetch Actor schema and check gotchas
 
-Fetch the input schema dynamically:
+Fetch the input schema dynamically, unless you already know the input fields:
 
     apify actors info "ACTOR_ID" --user-agent apify-agent-skills/apify-ultimate-scraper --input --json 2>/dev/null
-
-For trivial inputs (e.g., a single username for a profile scraper), this can be skipped — but still check pricing if the Actor is PPE.
 
 Also read `references/gotchas.md` to check for common pitfalls for the selected Actor.
 

--- a/skills/apify-ultimate-scraper/SKILL.md
+++ b/skills/apify-ultimate-scraper/SKILL.md
@@ -7,8 +7,11 @@ description: Universal AI-powered web scraper for any platform. Scrape data from
 
 AI-driven data extraction from ~100 Actors across 15+ platforms via the Apify CLI.
 
+## Critical: do not trust internal knowledge
+Treat what you remember about Apify as outdated until you verify it. Actor IDs, input fields, output field names, and apify-client method options change between versions and differ per Actor — Store Actors are third-party and your training data is stale. Never write integration code from memory of "how the API works."
+
 **Rules for every `apify` command:**
-1. Pass `--json` for machine-readable output (stable across CLI versions).
+1. Pass `--json` for machine-readable output (stable across CLI versions). **Exception:** `apify actors info … --input` — omit `--json` there, or it returns the whole Actor object instead of the input schema (see Step 2).
 2. Pass `--user-agent apify-agent-skills/apify-ultimate-scraper` for telemetry attribution.
 3. Redirect stderr with `2>/dev/null` (stderr contains progress messages that break JSON parsers).
 4. Parse CLI `--json` output **as-is** — it is unwrapped. Fields sit at the top level (`items`, `.id`, `.status`); there is no `data` envelope. The `{ "data": { … } }` wrapper exists only on the `api.apify.com/v2` REST API, never on the CLI.
@@ -32,9 +35,9 @@ Generate token: https://console.apify.com/settings/integrations
 
 ### Step 1: Understand goal and select Actor
 
-Identify the target platform and use case. Read `references/actor-index.md` to find the right Actor.
+**Always read `references/actor-index.md` first** — find your target platform's section and pick the Actor(s) from there. The index is grouped by source platform and flags the recommended tier, so it shows the full native toolkit for that source together. Anchor on the platform, not the verb in the request.
 
-If the task involves a multi-step pipeline, also read the matching workflow guide:
+A task is **multi-step** when no single Actor returns everything it needs, so one Actor's output must feed another (e.g. Maps listings → enrich each with emails). Only then, read the matching guide to chain them — it shows the handoff, i.e. which output field becomes the next Actor's input:
 
 | Task involves... | Read |
 |-----------------|------|
@@ -73,7 +76,9 @@ If dynamic search also returns nothing suitable, fall back to a generic crawler 
 
 Fetch the input schema dynamically, unless you already know the input fields:
 
-    apify actors info "ACTOR_ID" --user-agent apify-agent-skills/apify-ultimate-scraper --input --json 2>/dev/null
+    apify actors info "ACTOR_ID" --user-agent apify-agent-skills/apify-ultimate-scraper --input 2>/dev/null
+
+**Omit `--json` here** (the exception to Rule #1). `--input` alone prints the input schema directly (`title`, `description`, `properties`, `required`). Adding `--json` flips it to the *full Actor object* and buries the schema ~hundreds of KB deep under `taggedBuilds.latest.build.actorDefinition.input` — don't go digging there.
 
 Also read `references/gotchas.md` to check for common pitfalls for the selected Actor.
 


### PR DESCRIPTION
Fixes #50 — see the issue for full context (the eval prompts that surfaced each issue, what we observed, why it happens, and the proposed fix).

## Summary

Doc clarifications across three skills so an agent reliably **picks the right Actor**, **reads input schemas the correct way**, and **doesn't abandon the CLI on an opaque failure** — plus a companion evals framework. Root-caused from agent eval runs where the agent chose a suboptimal Actor, skipped `actor-index.md`, burned ~25 tool calls reverse-engineering a schema, and (in a later run) bailed from the CLI to `apify-client` → hand-rolled `cheerio` after a silently-suppressed error.

Net skill diff vs `main`: **32 insertions, 8 deletions** across three `SKILL.md` files (mostly additive). The `evals/` folder is the remainder.

### `apify-ultimate-scraper`
- **Critical: do not trust internal knowledge** — treat remembered Actor IDs, input/output fields, and client methods as stale; verify before writing integration code.
- **Select by source, not the verb** — anchor Actor choice on the source platform, not the action word in the request.
- **Read `actor-index.md` first** — it's grouped by platform and flags the recommended tier, so a source's native toolkit shows together. Defines when a task is *multi-step* (one Actor's output must feed another) and that the workflow guide carries the **handoff**.
- **Schema-fetch fix** — `apify actors info … --input` **without** `--json` prints the schema directly; with `--json` it returns the whole Actor object and buries the schema under `taggedBuilds.latest.build.actorDefinition.input`. Documented as the explicit exception to the global "always `--json`" rule.
- **Don't blind-suppress errors** — keep `2>/dev/null` for clean JSON, but on empty/unexpected output **re-run without it and read the error** before switching approach. Suppressing the CLI's (specific, fix-naming) errors turns a recoverable failure into a CLI→SDK→hand-rolled spiral.
- **`--input-file` for file input** — `-i` is inline JSON only; pass a file with `--input-file=PATH` (or `-f`). `-i @PATH` is a curl-ism the CLI rejects.
- CLI `--json` is **unwrapped** (results under `items`, no `data` envelope) + a literal example block; generic-crawler fallback rule.

### `apify-sdk-integration`
- Get schemas via the CLI (`apify actors info … --input`); **do not** read `.inputSchema` off `client.actor(id).get()` — the Actor object doesn't include it.
- Boundary note: **not for one-off scrapes** — use the CLI via `apify-ultimate-scraper`; reach for `apify-client` only when building an app.
- Actor-ID format note + corrected pagination default.

### `apify-actor-development`
- Clarify `apify create -t` takes the manifest's `name`, not its `id`.

## Companion: `evals/` folder

A small two-layer eval framework (`routing.json` + per-skill behavioral files) that surfaced these issues. Kept in its own commits so it can be dropped or factored out if you'd rather not adopt evals in this repo.

## How to review

```bash
# Just the skill edits
git diff main -- 'skills/**/SKILL.md'

# Full diff (skill edits + evals folder)
git diff main
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
