### PR TITLE
docs: clarify apify create -t uses template name, not id

### DIFF
--- a/skills/apify-actor-development/SKILL.md
+++ b/skills/apify-actor-development/SKILL.md
@@ -63,6 +63,8 @@ If browser login isn't available (headless environment or CI), the CLI automatic
 
 Use the appropriate CLI command based on the user's language choice. Additional packages (Crawlee, Playwright, etc.) can be installed later as needed.
 
+**For other templates (Crawlee + Cheerio, Playwright, Camoufox, etc.):** the `-t` value is the manifest's **`name`** field, not the `id` field (e.g. `apify create my-actor -t project_cheerio_crawler_ts`, not `ts-crawlee-cheerio`). Look up the `name` here: https://raw.githubusercontent.com/apify/actor-templates/master/templates/manifest.json
+
 ## Quick start workflow
 
 1. **Create Actor project** - Run the appropriate `apify create` command based on user's language preference (see Template selection above)


### PR DESCRIPTION
Fixes the `apify-actor-development` skill so agents pick the correct `-t` value for templates beyond the three defaults: the `-t` argument is the manifest's `name` field, not the more-prominent `id` field. Adds a one-line note with an example and a link to the template manifest.

Addresses issue #4 in #50.