### PR TITLE
docs(apify-actor-development): add remote-first guidance for Playwright Actors

### DIFF
--- a/skills/apify-actor-development/SKILL.md
+++ b/skills/apify-actor-development/SKILL.md
@@ -206,6 +206,37 @@ This file should contain the input parameters defined in your `.actor/input_sche
 - To verify results on Apify Console, you must deploy the Actor with `apify push` and then run it on the platform.
 - Do **not** rely on checking Apify Console to verify results from local runs — instead, inspect the local `storage/` directory or check the Actor's log output.
 
+## Testing Playwright (and other browser-based) Actors
+
+**Prefer remote-first testing for any browser-based Actor.** Playwright bundles Chromium, but running it locally requires a set of native system libraries (`glibc`, `libnss3`, `libatk`, fonts, and more). Many agent sandboxes, minimal containers, and CI runners are missing these — so `apify run` for a Playwright Actor fails in ways that look like the code is broken, when the environment is really the problem. Typical failure signatures include:
+
+```
+browserType.launch: Failed to launch: Error: spawn .../chrome-headless-shell ENOENT
+ls: /lib64/ld-linux-x86-64.so.2: No such file or directory
+su: must be suid to work properly. Failed to install browser dependencies.
+```
+
+Rather than fighting the sandbox, deploy and run remotely — the Apify platform's Actor images already have every browser dependency preinstalled.
+
+**Recommended workflow for browser-based Actors:**
+
+1. Skip `apify run` locally. Do everything else (schema, code, README) as usual.
+2. Deploy with `apify push`.
+3. Trigger a real run with `apify call <actor> --input-file input.json` (or inline `--input '{...}'`).
+4. Inspect the run's log, dataset, and key-value store output on Apify Console or via `apify runs ls` + `apify api`.
+
+**Sandbox capability check.** If you want to decide programmatically whether the current environment can run Playwright locally, probe for the dynamic linker Playwright's bundled Chromium needs:
+
+```bash
+if [ ! -e /lib64/ld-linux-x86-64.so.2 ] && [ ! -e /lib/x86_64-linux-gnu/ld-linux-x86-64.so.2 ]; then
+  echo "Local browsers unlikely to launch here — use apify push + apify call instead."
+fi
+```
+
+**Do not run `npx playwright install-deps` in unprivileged environments.** It requires `sudo` / root to install apt packages and will fail loudly (`su: must be suid to work properly`) inside most agent sandboxes and rootless containers. This is expected — treat it as a signal to move to remote testing, not something to work around.
+
+Non-browser Actors (Cheerio, plain HTTP, Python `requests`, etc.) are unaffected — `apify run` remains the right local loop for them.
+
 ## Standby mode
 
 Standby mode enables Actors to work as API servers - they remain ready in the background to handle HTTP requests.


### PR DESCRIPTION
## Summary

Add a new section to `skills/apify-actor-development/SKILL.md` that tells agents to skip local `apify run` for browser-based Actors and go straight to `apify push` + `apify call`. Playwright's bundled Chromium requires native system libraries that many agent sandboxes, minimal containers, and CI runners don't ship — so today agents spend several turns diagnosing what looks like Actor bugs but is really an environment gap.

## Problem

When an agent scaffolds a Playwright / PlaywrightCrawler Actor and runs `apify run` inside a typical agent sandbox or minimal container, one of three failure modes shows up:

1. **Chromium binary missing / unlaunchable:**
   ```
   browserType.launch: Failed to launch: Error: spawn .../chrome-headless-shell ENOENT
   ```

2. **Dynamic linker missing (musl-based or stripped images):**
   ```
   ls: /lib64/ld-linux-x86-64.so.2: No such file or directory
   ```

3. **`playwright install-deps` cannot escalate:**
   ```
   su: must be suid to work properly
   Failed to install browser dependencies
   ```

All three look like Actor code bugs, but the fix is always the same: run remotely on the Apify platform, whose Actor images already include glibc, libnss3, libatk, fonts, and the rest of the Chromium runtime.

## Fix

New section **"Testing Playwright (and other browser-based) Actors"** in `SKILL.md`, placed right after the existing "Local testing" section. It:

- Recommends skipping local `apify run` for browser Actors and going straight to `apify push` + `apify call`.
- Quotes the three typical error signatures verbatim so agents recognize them fast and pivot instead of chasing the code.
- Provides a small capability probe:
  ```bash
  if [ ! -e /lib64/ld-linux-x86-64.so.2 ] && [ ! -e /lib/x86_64-linux-gnu/ld-linux-x86-64.so.2 ]; then
    echo "Local browsers unlikely to launch here — use apify push + apify call instead."
  fi
  ```
- Warns explicitly against running `npx playwright install-deps` in unprivileged environments (it needs root apt access).
- Clarifies that non-browser Actors (Cheerio, plain HTTP, Python `requests`) are unaffected — `apify run` remains the right local loop for them.

Docs-only change; no code paths touched.

## Test plan

- [ ] `skills/apify-actor-development/SKILL.md` renders with a new "Testing Playwright (and other browser-based) Actors" section between "Local testing" and "Standby mode".
- [ ] The ld-linux-so heuristic and the three verbatim error strings are present so agents can grep for them.
- [ ] An agent scaffolding a fresh PlaywrightCrawler Actor in a sandboxed environment reads this section and goes straight to `apify push` + `apify call` on the first attempt instead of debugging local browser launches.

_Surfaced during an evaluation of Apify surfaces for agent-driven Actor development._