### PR TITLE
docs(apify-actor-development): require explicit `.inputSchema` reference in actor.json (auto-discovery deprecated)

### DIFF
--- a/skills/apify-actor-development/SKILL.md
+++ b/skills/apify-actor-development/SKILL.md
@@ -238,6 +238,8 @@ See [references/actor-json.md](references/actor-json.md) for complete actor.json
 
 See [references/input-schema.md](references/input-schema.md) for input schema structure and examples.
 
+When you create an input schema file, reference it explicitly from `.actor/actor.json` — either inline (`"inputSchema": { "type": "object", ... }`) or by path (`"inputSchema": "./input_schema.json"`, relative to `.actor/`). Do not rely on auto-discovery of `.actor/INPUT_SCHEMA.json` or root `INPUT_SCHEMA.json`; that fallback is deprecated per the input-schema specification and may be removed in a future platform release. The deprecated `.input` field is still recognized for backwards compatibility but should not be used in new Actors.
+
 ## Output schema
 
 See [references/output-schema.md](references/output-schema.md) for output schema structure, examples, and template variables.


### PR DESCRIPTION
## Rationale

The current `## Input schema` section in `skills/apify-actor-development/SKILL.md` links to `references/input-schema.md` but does not surface a common pitfall in SKILL.md itself: when an input schema file is created, `.actor/actor.json` must reference it explicitly via the `inputSchema` field. Relying on the historical auto-discovery of `.actor/INPUT_SCHEMA.json` or root `INPUT_SCHEMA.json` is deprecated per the input-schema specification and may be removed in a future platform release. Some tutorials and templates still show file creation without the linkage — that omission is the gap, not the recommended pattern.

This adds a short paragraph so agents following SKILL.md wire the schema up correctly the first time, instead of producing Actors that appear to configure input but fall through to a deprecated fallback.

## Added content (verbatim)

> When you create an input schema file, reference it explicitly from `.actor/actor.json` — either inline (`"inputSchema": { "type": "object", ... }`) or by path (`"inputSchema": "./input_schema.json"`, relative to `.actor/`). Do not rely on auto-discovery of `.actor/INPUT_SCHEMA.json` or root `INPUT_SCHEMA.json`; that fallback is deprecated per the input-schema specification and may be removed in a future platform release. The deprecated `.input` field is still recognized for backwards compatibility but should not be used in new Actors.

_Surfaced during an evaluation of Apify surfaces for agent-driven Actor development._