### PR TITLE
docs(apify-actor-development): create `.actorignore` after scaffolding

### DIFF
--- a/skills/apify-actor-development/SKILL.md
+++ b/skills/apify-actor-development/SKILL.md
@@ -63,6 +63,24 @@ If browser login isn't available (headless environment or CI), the CLI automatic
 
 Use the appropriate CLI command based on the user's language choice. Additional packages (Crawlee, Playwright, etc.) can be installed later as needed.
 
+### Create `.actorignore` after scaffolding
+
+Apify templates (including `ts_empty`, `project_empty`, `python-empty`) do not include a `.actorignore` file, even though `apify push` honors one if present. Without it, every `apify push` uploads `node_modules/`, `dist/`, build caches, `.git/`, and anything else in the working tree — bloating the upload and shipping local build artifacts the multi-stage Dockerfile regenerates anyway.
+
+Create `.actorignore` at the project root with at minimum:
+
+```
+node_modules
+dist
+.git
+.env*
+*.log
+coverage
+.DS_Store
+```
+
+Syntax is `.gitignore`-style.
+
 ## Quick start workflow
 
 1. **Create Actor project** - Run the appropriate `apify create` command based on user's language preference (see Template selection above)


### PR DESCRIPTION
## Rationale

Apify templates (`ts_empty`, `project_empty`, `python-empty`) do not ship a `.actorignore` file, yet `apify push` honors one if present. Without it, every push uploads `node_modules/`, `dist/`, `.git/`, and other build caches — bloating uploads and shipping local artifacts that the multi-stage Dockerfile regenerates anyway.

This adds a short subsection under `## Template selection` telling the agent to create `.actorignore` immediately after scaffolding, with a minimal starter set.

## Added content preview

> ### Create `.actorignore` after scaffolding
>
> Apify templates (including `ts_empty`, `project_empty`, `python-empty`) do not include a `.actorignore` file, even though `apify push` honors one if present. Without it, every `apify push` uploads `node_modules/`, `dist/`, build caches, `.git/`, and anything else in the working tree — bloating the upload and shipping local build artifacts the multi-stage Dockerfile regenerates anyway.
>
> Create `.actorignore` at the project root with at minimum:
>
> ```
> node_modules
> dist
> .git
> .env*
> *.log
> coverage
> .DS_Store
> ```
>
> Syntax is `.gitignore`-style.

_Surfaced during an evaluation of Apify surfaces for agent-driven Actor development._