### PR TITLE
docs(apify-actor-development): clarify AI / LLM Actors are just Actors that call an LLM

### DIFF
--- a/skills/apify-actor-development/SKILL.md
+++ b/skills/apify-actor-development/SKILL.md
@@ -122,6 +122,10 @@ Use the appropriate CLI command based on the user's language choice. Additional 
 - Use `console.log()` or `print()` instead of the Apify logger — these bypass credential censoring
 - Disable standby mode without explicit permission
 
+## AI / LLM Actors
+
+An "AI Actor" is just an Actor whose work happens to be calling an external LLM API — not a distinct construct, not an agent framework. Use the model vendor's SDK (e.g. `@anthropic-ai/sdk`, `openai`) to call the model, and the Apify SDK for input parsing, dataset writes, key-value store, and proxy config. Package it like any other Actor.
+
 ## Logging
 
 See [references/logging.md](references/logging.md) for complete logging documentation including available log levels and best practices for JavaScript/TypeScript and Python.


### PR DESCRIPTION
## Rationale

Users building LLM-powered Actors sometimes reach for agent frameworks or assume there is a special "AI Actor" construct in Apify. There isn't — an AI Actor is just an Actor whose work happens to be calling an external LLM API, with the same packaging conventions as any other Actor. A one-paragraph framing under `apify-actor-development` clarifies the mental model up front and steers builders away from over-engineering.

## Change

Adds a short standalone `## AI / LLM Actors` section between `## Best practices` and `## Logging` in `skills/apify-actor-development/SKILL.md`.

## Added content (verbatim)

> ### AI / LLM Actors
>
> An "AI Actor" is just an Actor whose work happens to be calling an external LLM API — not a distinct construct, not an agent framework. Use the model vendor's SDK (e.g. `@anthropic-ai/sdk`, `openai`) to call the model, and the Apify SDK for input parsing, dataset writes, key-value store, and proxy config. Package it like any other Actor.

_Surfaced during an evaluation of Apify surfaces for agent-driven Actor development._