### PR TITLE
docs(apify-actor-development): clarify `apify push` needs `apify login`, not just APIFY_TOKEN

### DIFF
--- a/skills/apify-actor-development/SKILL.md
+++ b/skills/apify-actor-development/SKILL.md
@@ -48,6 +48,10 @@ apify login
 
 If browser login isn't available (headless environment or CI), the CLI automatically reads `APIFY_TOKEN` from the environment. Ensure the env var is exported and run any apify command - no explicit login needed. If the user doesn't have a token, generate one at https://console.apify.com/settings/integrations.
 
+> **Headless / CI note:** `apify info` and `apify api` read `APIFY_TOKEN` from the environment, but `apify push` reads its token from `~/.apify/auth.json` populated by `apify login`. In a non-interactive environment where you cannot complete the OAuth flow, run `apify login --token "$APIFY_TOKEN"` once at session start; otherwise `apify push` fails with a 401 despite `apify info` succeeding.
+>
+> `apify push` is already non-interactive once a token is stored — there is no `--yes` / `--no-prompt` flag. Use `apify push --force` to skip the confirmation when overwriting a build of an existing version.
+
 > **Security note:** Avoid passing tokens as command-line arguments (e.g. `apify login -t <token>`).
 > Arguments are visible in process listings and may be recorded in shell history.
 > Prefer environment variables or interactive login instead.


### PR DESCRIPTION
## Rationale

The `## Prerequisites and setup (mandatory)` section currently tells agents that in headless / CI environments the CLI "automatically reads `APIFY_TOKEN` from the environment... no explicit login needed." That is accurate for `apify info` and `apify api`, but empirically **not** true for `apify push`, which reads its token from `~/.apify/auth.json` (populated by `apify login`) and does not consult `APIFY_TOKEN` at deploy time.

The visible failure mode is confusing: an agent following the current guidance sees `apify info` succeed, concludes it is authenticated, then `apify push` fails with a 401 wrapped in unstructured error prose (exit 1). This PR amends the last paragraph of that section with a headless / CI caveat so agents run `apify login --token "$APIFY_TOKEN"` at session start.

While in the same paragraph, this also documents that `apify push` has no `--yes` / `--no-prompt` flag — `--force` is the one to use for overwriting an existing build.

## Added content (preview)

> **Headless / CI note:** `apify info` and `apify api` read `APIFY_TOKEN` from the environment, but `apify push` reads its token from `~/.apify/auth.json` populated by `apify login`. In a non-interactive environment where you cannot complete the OAuth flow, run `apify login --token "$APIFY_TOKEN"` once at session start; otherwise `apify push` fails with a 401 despite `apify info` succeeding.
>
> `apify push` is already non-interactive once a token is stored — there is no `--yes` / `--no-prompt` flag. Use `apify push --force` to skip the confirmation when overwriting a build of an existing version.

_Surfaced during an evaluation of Apify surfaces for agent-driven Actor development._