### PR TITLE
docs(apify-actor-development): document REST deploy path (PUT versions with JSON sourceFiles)

### DIFF
--- a/skills/apify-actor-development/SKILL.md
+++ b/skills/apify-actor-development/SKILL.md
@@ -180,6 +180,14 @@ Actor input is one JSON object, not an array. `--input` accepts inline JSON obje
 
 If no dedicated Actor exists for your target, search Apify Store for community options before building from scratch.
 
+### Deploying without the CLI (REST API)
+
+If `apify-cli` isn't available, deploy via `PUT /v2/acts/{actorId}/versions/{versionNumber}` with a JSON body whose `sourceType` and inline `sourceFiles` (base64 for binaries, plain text for text files) describe each file — see the [Update version reference](https://docs.apify.com/api/v2#/reference/actor-versions/version-object/update-version). Use `POST /v2/acts/{actorId}/versions` to create a new version, `PUT` to overwrite an existing one; there is no `?overwrite=true` or `?force=1` query parameter — overwrite semantics are governed by the HTTP verb.
+
+Avoid the sibling `PUT /v2/acts/{id}/versions/{ver}/source-files` tarball endpoint. It is documented but currently returns 4xx regardless of payload shape; use the JSON `sourceFiles` form instead.
+
+The `MAJOR.MINOR` version regex (each segment 0-99) applies to this endpoint as well — see the actor.json reference.
+
 ### Local and runtime commands
 
 Always use `apify run` to test Actors locally. Do not use `npm run start`, `npm start`, `yarn start`, or other package manager commands - these will not properly configure the Apify environment and storage.


### PR DESCRIPTION
## Rationale

When `apify-cli` isn't available (API-only or MCP-only workflows), agents attempting to deploy Actor source via REST hit two silent pitfalls:

1. The sibling `PUT /v2/acts/{id}/versions/{ver}/source-files` tarball endpoint is documented but currently 4xx's on any payload shape.
2. Invented query params like `?overwrite=true` or `?force=1` don't exist — overwrite semantics are governed by the HTTP verb (`POST` to create, `PUT` to overwrite).

The correct path is `PUT /v2/acts/{actorId}/versions/{versionNumber}` with a JSON body describing files via `sourceType` + inline `sourceFiles` (base64 for binaries, plain text for text files). This addition documents that path directly in the actor-development skill so agents pick the working endpoint on the first try.

## Added content (preview)

> ### Deploying without the CLI (REST API)
>
> If `apify-cli` isn't available, deploy via `PUT /v2/acts/{actorId}/versions/{versionNumber}` with a JSON body whose `sourceType` and inline `sourceFiles` (base64 for binaries, plain text for text files) describe each file — see the [Update version reference](https://docs.apify.com/api/v2#/reference/actor-versions/version-object/update-version). Use `POST /v2/acts/{actorId}/versions` to create a new version, `PUT` to overwrite an existing one; there is no `?overwrite=true` or `?force=1` query parameter — overwrite semantics are governed by the HTTP verb.
>
> Avoid the sibling `PUT /v2/acts/{id}/versions/{ver}/source-files` tarball endpoint. It is documented but currently returns 4xx regardless of payload shape; use the JSON `sourceFiles` form instead.
>
> The `MAJOR.MINOR` version regex (each segment 0-99) applies to this endpoint as well — see the actor.json reference.

_Surfaced during an evaluation of Apify surfaces for agent-driven Actor development._