### PR TITLE
fix: use canonical /v2/actors and /v2/actor-runs routes in SDK integration skill

### DIFF
--- a/skills/apify-sdk-integration/SKILL.md
+++ b/skills/apify-sdk-integration/SKILL.md
@@ -169,7 +169,7 @@ For languages without an official client, use the REST API directly.
 ### Start a Run
 
 ```
-POST https://api.apify.com/v2/acts/{actorId}/runs
+POST https://api.apify.com/v2/actors/{actorId}/runs
 Authorization: Bearer <APIFY_TOKEN>
 Content-Type: application/json
 
@@ -179,7 +179,7 @@ Content-Type: application/json
 ### Get Run Status
 
 ```
-GET https://api.apify.com/v2/acts/{actorId}/runs/{runId}
+GET https://api.apify.com/v2/actor-runs/{runId}
 Authorization: Bearer <APIFY_TOKEN>
 ```
 


### PR DESCRIPTION
Relates to apify/apify-docs#2804

Replace the legacy `/v2/acts` prefix in the REST API section of `apify-sdk-integration`. The prefix is an undocumented alias absent from the public OpenAPI contract.

- `POST /v2/acts/{actorId}/runs` → `/v2/actors/{actorId}/runs`
- `GET /v2/acts/{actorId}/runs/{runId}` → `/v2/actor-runs/{runId}` — not a prefix swap; the Actor-scoped single-run route is `deprecated: true` in the spec

This file is a manual copy of the same skill in `apify-plugins-internal`, which isn't a sync target. Source PR: apify/apify-plugins-internal#23
