### PR TITLE
docs(skills): correct APIFY_TOKEN CLI authentication guidance

### DIFF
--- a/commands/create-actor.md
+++ b/commands/create-actor.md
@@ -46,7 +46,7 @@ Initial request: $ARGUMENTS
 3. Verify authentication: `apify info`
 4. If not logged in:
    - Authenticate using OAuth (opens browser): `apify login`
-   - If browser isn't available, ensure `APIFY_TOKEN` env var is exported (the CLI reads it automatically)
+   - If browser isn't available, log in non-interactively: `apify login --token TOKEN` (the CLI does not read the `APIFY_TOKEN` env var)
    - If user doesn't have a token, generate one at https://console.apify.com/settings/integrations
 
 ---

--- a/skills/apify-actor-development/SKILL.md
+++ b/skills/apify-actor-development/SKILL.md
@@ -46,11 +46,21 @@ If not logged in, authenticate using OAuth (opens browser):
 apify login
 ```
 
-If browser login isn't available (headless environment or CI), the CLI automatically reads `APIFY_TOKEN` from the environment. Ensure the env var is exported and run any apify command - no explicit login needed. If the user doesn't have a token, generate one at https://console.apify.com/settings/integrations.
+If browser login isn't available (headless environment or CI), log in non-interactively:
 
-> **Security note:** Avoid passing tokens as command-line arguments (e.g. `apify login -t <token>`).
-> Arguments are visible in process listings and may be recorded in shell history.
-> Prefer environment variables or interactive login instead.
+```bash
+apify login --token TOKEN
+```
+
+The CLI does **not** read `APIFY_TOKEN` from the environment — exporting it will not log you in.
+`apify login` is the only way to authenticate the CLI; it stores credentials in your OS keyring (or
+`~/.apify/auth.json`) and reuses them automatically. `APIFY_TOKEN` is read by the Apify SDK inside a
+running Actor, where the platform injects it (and `apify run` injects your stored token locally). If
+the user doesn't have a token, generate one at https://console.apify.com/settings/integrations.
+
+> **Security note:** A token passed as a command-line argument is visible in process listings and may be
+> recorded in shell history. Prefer interactive `apify login` when a browser is available. When it isn't,
+> use `apify login --token` but pass the token from a variable or secret store rather than typing it inline.
 > Never log, print, or embed `APIFY_TOKEN` in source code or configuration files.
 > Use a token with the minimum required permissions (scoped token) and rotate it periodically.
 

--- a/skills/apify-actorization/SKILL.md
+++ b/skills/apify-actorization/SKILL.md
@@ -54,13 +54,22 @@ If not logged in, authenticate using OAuth (opens browser):
 apify login
 ```
 
-If browser login isn't available (headless environment or CI), ensure the `APIFY_TOKEN` environment variable is exported (note: the variable is `APIFY_TOKEN`, not `APIFY_API_TOKEN`). The CLI reads it automatically - no explicit login needed. If the user doesn't have a token, generate one at https://console.apify.com/settings/integrations.
+If browser login isn't available (headless environment or CI), log in non-interactively:
 
-> **Apify platform environment:** When the Actor runs on the Apify platform, `APIFY_TOKEN` is auto-injected as an environment variable and the Apify SDK reads it automatically — you do not need to pass it explicitly. Locally, `apify login` stores credentials in `~/.apify` and the SDK uses them.
+```bash
+apify login --token TOKEN
+```
 
-> **Security note:** Avoid passing tokens as command-line arguments (e.g. `apify login -t <token>`).
-> Arguments are visible in process listings and may be recorded in shell history.
-> Prefer OAuth login or environment variables instead.
+The CLI does **not** read `APIFY_TOKEN` from the environment — exporting it will not log you in.
+`apify login` is the only way to authenticate the CLI; it stores credentials in your OS keyring (or
+`~/.apify/auth.json`) and reuses them automatically. If the user doesn't have a token, generate one
+at https://console.apify.com/settings/integrations.
+
+> **Apify platform environment:** When the Actor runs on the Apify platform, `APIFY_TOKEN` is auto-injected as an environment variable and the Apify SDK reads it automatically (note: the variable is `APIFY_TOKEN`, not `APIFY_API_TOKEN`) — you do not need to pass it explicitly. Locally, `apify login` stores credentials in `~/.apify` and the SDK uses them.
+
+> **Security note:** A token passed as a command-line argument is visible in process listings and may be
+> recorded in shell history. Prefer interactive `apify login` when a browser is available. When it isn't,
+> use `apify login --token` but pass the token from a variable or secret store rather than typing it inline.
 > Never log, print, or embed `APIFY_TOKEN` in source code or configuration files.
 > Use a token with the minimum required permissions (scoped token) and rotate it periodically.
 

--- a/skills/apify-ultimate-scraper/SKILL.md
+++ b/skills/apify-ultimate-scraper/SKILL.md
@@ -22,8 +22,9 @@ AI-driven data extraction from ~100 Actors across 15+ platforms via the Apify CL
 If a CLI command fails with an auth error, authenticate using one of these methods:
 
 1. **OAuth (interactive):** `apify login` (opens browser)
-2. **Environment variable:** `export APIFY_TOKEN=your_token_here`
-3. **From .env file:** `source .env` (if the file contains `APIFY_TOKEN=...`)
+2. **Non-interactive (headless or CI):** `apify login --token TOKEN`
+
+Exporting `APIFY_TOKEN` does **not** authenticate the CLI — it only reads credentials stored by `apify login`.
 
 Generate token: https://console.apify.com/settings/integrations
 


### PR DESCRIPTION
Relates to apify/apify-plugins-internal#21

The skills told agents the Apify CLI reads `APIFY_TOKEN` from the environment. It doesn't — `getToken()` reads the OS keyring or `~/.apify/auth.json` and never touches `process.env`. Agents following this exported the variable, got "not logged in", and had no next step.

All four files now point to `apify login --token TOKEN` for headless auth, and explain that `APIFY_TOKEN` is read by the Apify SDK inside a running Actor rather than by the CLI.

In `apify-actor-development` and `apify-actorization` the security note said to "prefer environment variables" over `apify login -t`. Fixing only the wrong sentence would have left that note steering agents away from the one method that works headlessly, so the warning is kept but redirected: pass the token from a variable or secret store rather than typing it inline.

`skills/apify-sdk-integration/SKILL.md` is untouched — its `APIFY_TOKEN` references are about the SDK and are correct.