### PR TITLE
docs(actor-index): add LinkedIn hire-tracking and post-engager gaps

### DIFF
--- a/skills/apify-ultimate-scraper/references/actor-index.md
+++ b/skills/apify-ultimate-scraper/references/actor-index.md
@@ -92,11 +92,13 @@ Tiers: `apify` = Apify-maintained (always prefer), `community` = community-maint
 | harvestapi/linkedin-profile-scraper | community | profile with email |
 | harvestapi/linkedin-company | community | company details |
 | harvestapi/linkedin-company-employees | community | employee lists |
+| george.the.developer/linkedin-company-employees-scraper | community | new hires, departures, weekly employee-change tracking |
 | harvestapi/linkedin-company-posts | community | company page posts |
 | harvestapi/linkedin-profile-posts | community | profile posts |
 | harvestapi/linkedin-job-search | community | job listings |
 | harvestapi/linkedin-post-search | community | post search |
 | harvestapi/linkedin-post-comments | community | post comments |
+| george.the.developer/linkedin-post-engagers-scraper | community | post commenters and reactors as filtered leads |
 | harvestapi/linkedin-profile-search-by-name | community | find by name |
 | harvestapi/linkedin-profile-search-by-services | community | find by service |
 | apimaestro/linkedin-companies-search-scraper | community | company search |


### PR DESCRIPTION
## Why

The LinkedIn section currently routes every employee-list and comment job to harvestapi / apimaestro. Two jobs the index does not name already have dedicated community actors:

1. **Weekly new-hire / departure tracking** (not a one-shot employee dump). `george.the.developer/linkedin-company-employees-scraper` — no login, charges only verified current-employer profiles, free monitoring vs the previous run. Live `/v2/acts` count on 2026-08-15: **141 users / 30 days**, 1,923 lifetime.

2. **Post commenters and reactors as filtered leads** (not raw comment text). `george.the.developer/linkedin-post-engagers-scraper` — ICP filter on job-title keywords, one charged row per matched lead. harvestapi/linkedin-post-comments stays the right pick for raw comments.

harvestapi rows are unchanged. Agents asking for employee lists or post comments still get harvestapi. Agents asking for churn / new hires or engager leads now have a named row.

## Change

One file: `skills/apify-ultimate-scraper/references/actor-index.md`. Two community rows. No new skill, no version bump.

## Test plan

- [x] harvestapi/linkedin-company-employees still listed as employee lists
- [x] harvestapi/linkedin-post-comments still listed as post comments
- [ ] Maintainer: actor IDs resolve on the Store