### PR TITLE
docs(actor-index): add job-board, remote-jobs, local-leads and creator-email routes

### DIFF
--- a/skills/apify-ultimate-scraper/references/actor-index.md
+++ b/skills/apify-ultimate-scraper/references/actor-index.md
@@ -73,6 +73,7 @@ Tiers: `apify` = Apify-maintained (always prefer), `community` = community-maint
 | streamers/youtube-video-scraper-by-hashtag | apify | videos by hashtag |
 | streamers/youtube-video-downloader | apify | video download |
 | curious_coder/youtube-transcript-scraper | community | transcripts, captions |
+| flash_scraper/creator-leads-scraper | community | creators by keyword with published emails; hops to linked Instagram/TikTok |
 
 ## X/Twitter
 
@@ -109,6 +110,13 @@ Tiers: `apify` = Apify-maintained (always prefer), `community` = community-maint
 | apimaestro/linkedin-profile-full-sections-scraper | community | full profile data |
 | dev_fusion/linkedin-profile-scraper | community | mass scraping + email |
 
+## Job boards
+
+| Actor | Tier | Best for |
+|-------|------|----------|
+| flash_scraper/multi-jobboard-scraper | community | LinkedIn + Indeed + Glassdoor + The Muse in one run, deduplicated across boards; Greenhouse/Lever/Ashby careers pages |
+| flash_scraper/remote-job-aggregator | community | remote-only jobs from 10 boards (RemoteOK, We Work Remotely, Remotive, Jobicy, Himalayas, HN) |
+
 ## Google Maps
 
 | Actor | Tier | Best for |
@@ -120,6 +128,7 @@ Tiers: `apify` = Apify-maintained (always prefer), `community` = community-maint
 | compass/contact-details-scraper-standby | apify | quick contact extract |
 | lukaskrivka/google-maps-with-contact-details | community | listings + contacts |
 | curious_coder/google-maps-reviews-scraper | community | cheap review scraping |
+| flash_scraper/local-business-leads | community | local business leads without Google Maps: OpenStreetMap discovery + site crawl + MX-verified emails |
 
 ## Google Search and Trends
 

--- a/skills/apify-ultimate-scraper/references/workflows/contact-enrichment.md
+++ b/skills/apify-ultimate-scraper/references/workflows/contact-enrichment.md
@@ -20,6 +20,24 @@ Step 2: `socialProfiles`, `linkedinCompanyUrl`, `facebookUrl`
 
 ---
 
+## Verified business emails for a website list, no third-party verifier
+**When:** User has a list of company or local-business websites and wants one contact email per domain, already MX-verified, plus phones and social links.
+
+### Pipeline
+1. **Crawl + verify in one run** -> `flash_scraper/local-business-leads`
+   - Key input: `websiteList` (bare domains or URLs; discovery is skipped), `verifyEmails: true`, `maxPagesPerSite` (default 3), `outputFields` to narrow the columns
+
+### Output fields
+Step 1: `domain`, `email`, `emails[]`, `email_status`, `email_type` (own domain / free inbox / marketing agency), `phones[]`, `facebook`, `instagram`, `linkedin`, `website_platform`, `lead_score`
+
+### Cost estimate
+PPE, $0.003 per delivered row on the free plan (Store pricing read 2026-09-05; a scheduled record raises it to $0.005 on 2026-09-14 - read the Actor's Pricing tab); verification is included, rows with no email can be dropped before billing with `onlyWithEmail: true`.
+
+### Gotcha
+A pattern-guessed `info@` address is only produced with `emailPatternGuess: true` and lands in a separate `email_guess` column - it is never promoted into `email`. Rows from `websiteList` carry `source: user_supplied` and a null `attribution`, so a mixed export keeps one header row.
+
+---
+
 ## LinkedIn warm lead identification from post comments
 **When:** User wants to find engaged prospects who commented on relevant LinkedIn posts (competitor content, thought leader posts, industry discussions).
 

--- a/skills/apify-ultimate-scraper/references/workflows/influencer-vetting.md
+++ b/skills/apify-ultimate-scraper/references/workflows/influencer-vetting.md
@@ -70,6 +70,25 @@ Step 3: `transcript` (raw text for AI topic classification)
 
 ---
 
+## Creator contact discovery by niche keyword
+**When:** User wants creators in a niche with a published contact email, across YouTube, Instagram and TikTok, as one table for sponsorship or affiliate outreach.
+
+### Pipeline
+1. **Discover on YouTube, hop to linked profiles, extract + verify emails** -> `flash_scraper/creator-leads-scraper`
+   - Key input: `searchKeywords`, `platforms`, `crossPlatformDiscovery: true`, `minFollowers`/`maxFollowers`, `onlyWithEmail`, `maxCreators`
+2. **Enrich handles from another discovery step** -> same Actor with `profiles` (TikTok) / `usernames` (Instagram) / `channels` (YouTube)
+
+### Output fields
+Step 1: `platform`, `handle`, `followers`, `email`, `email_source`, `email_status`, `website`, `instagram_url`, `tiktok_url`, `youtube_url`, `lead_score`, `also_on_platforms[]`, `matched_keyword`
+
+### Cost estimate
+PPE, $0.002 per creator delivered after filters on the free plan (Store pricing read 2026-09-05; no change scheduled as of that date, but the Pricing tab is authoritative). 50 creators = at most $0.10.
+
+### Gotcha
+Discovery is YouTube-only (about 30 channels per keyword); TikTok and Instagram are enriched from handles, never searched by keyword or hashtag - use `clockworks/tiktok-user-search-scraper` or `apify/instagram-hashtag-scraper` for that step. Email fill is what creators publish: the Actor README's 2026-08-09 runs measured 6 of 9 and 4 of 8 YouTube channels, 3 of 9 TikTok and 1 of 5 Instagram creators with an email after site enrichment. YouTube's "View email address" button is not read.
+
+---
+
 ## Cross-platform hashtag discovery
 **When:** User wants to discover new influencer candidates across Instagram, TikTok, and YouTube using niche hashtags for a unified shortlist.
 

--- a/skills/apify-ultimate-scraper/references/workflows/job-market-and-recruitment.md
+++ b/skills/apify-ultimate-scraper/references/workflows/job-market-and-recruitment.md
@@ -17,6 +17,40 @@ Step 2: `description`, `requirements`, `seniority`, `employmentType`, `salary`
 ### Gotcha
 Both Actors are PPE. Step 1: ~$0.001/job. Step 2: ~$0.005/job. For 200 jobs, total ~$1.20. Estimate and confirm with user.
 
+## Multi-board job search with cross-board deduplication
+**When:** User wants postings for a role and location from several boards (LinkedIn, Indeed, Glassdoor, The Muse) as one table, without the same job appearing once per board.
+
+### Pipeline
+1. **Search all boards in one run** -> `flash_scraper/multi-jobboard-scraper`
+   - Key input: `searchTerm`, `location`, `sites` (e.g. `["linkedin","indeed","glassdoor","muse"]`), `maxResults` (per board), `countryIndeed` (required for Indeed/Glassdoor), `strictKeywordMatch`
+2. **Watch named companies instead of boards** (optional) -> same Actor with `atsCompanies` (Greenhouse/Lever/Ashby boards read directly) and `onlyNewJobs: true` on a schedule; `webhookUrl` posts new rows to Slack/Discord
+
+### Output fields
+Step 1: `title`, `company`, `location`, `site`, `date_posted`, `job_url`, `found_on_sites[]`, `duplicate_count`, `salary_min`, `salary_max`, `salary_interval` (filled on 59-70% of rows on a default run with LinkedIn detail fetching on; 56-60% with it off, measured 2026-08-07/23)
+
+### Cost estimate
+PPE, $0.005/job on the free plan (Store pricing read 2026-09-05) plus a $0.00005 run start; deduplicated and filtered rows are not billed. 4 boards x 20 rows = at most $0.40.
+
+### Gotcha
+`maxResults` is per board, not per run. Salary is only present where the board publishes it; `requireSalary: true` drops the rest before billing. A board that throttles shows 0 rows in the log while the run still succeeds - rerun with a narrower term rather than a higher cap.
+
+## Remote-only job feed
+**When:** User wants remote jobs only, from the remote boards, with no city in the query.
+
+### Pipeline
+1. **Aggregate remote boards** -> `flash_scraper/remote-job-aggregator`
+   - Key input: `searchTerms`, `boards` (RemoteOK, We Work Remotely, Remotive, Jobicy, Himalayas, HN "Who is hiring", ...), `maxItems`, `matchDescriptions`, `postedWithinDays`, `salaryMinAnnual`, `countries`, `excludeKeywords`
+2. **Only new jobs on a schedule** (optional) -> `onlyNewJobs: true`
+
+### Output fields
+Step 1: `title`, `company`, `location`, `source_board`, `posted_at`, `url`, `job_id`, `salary_min`, `salary_max`, `salary_text` (salary on 35% of rows on the 2026-08-15 default run), `tags[]`, `seniority`, `job_type`
+
+### Cost estimate
+PPE, $0.002/job on the free plan (Store pricing read 2026-09-05; a scheduled record raises it to $0.003/job on 2026-09-14 - read the Actor's Pricing tab); a 100-row run is about $0.20, $0.30 after that date. No API key or proxy.
+
+### Gotcha
+`matchDescriptions: true` matches the keyword in descriptions as well as titles and multiplies volume (the Actor README's measured example: 28 rows title-only vs 194 with descriptions for `python`). Use `strictFilters: true` when the user complains about off-topic rows.
+
 ## Candidate sourcing
 **When:** User wants to find potential candidates matching specific criteria.
 

--- a/skills/apify-ultimate-scraper/references/workflows/lead-generation.md
+++ b/skills/apify-ultimate-scraper/references/workflows/lead-generation.md
@@ -19,6 +19,25 @@ Google Maps results vary by language and location. Set `language: "en"` explicit
 
 ---
 
+## Local business leads without Google Maps (OpenStreetMap + site crawl)
+**When:** User wants local-business emails and phones for a category and city but does not want Google Maps scraped (terms-of-service concerns, no proxy budget, or no need for Google ratings).
+
+### Pipeline
+1. **Discover + enrich + verify in one run** -> `flash_scraper/local-business-leads`
+   - Key input: `category`, `location` (or `categories` x `locations`), `maxItems`, `onlyWithWebsite`, `onlyVerifiedEmail`, `requirePhone`, `excludeChains`, `expandNearby`
+2. **Enrich a list the user already has** (optional) -> same Actor with `websiteList` (discovery skipped)
+
+### Output fields
+Step 1: `name`, `category`, `address`, `phone`, `website`, `email`, `email_status` (`deliverable`/`risky`/`undeliverable`), `email_type`, `facebook`, `instagram`, `linkedin`, `website_platform`, `lead_score`, `lead_grade`, `google_maps_url`, `osm_url`
+
+### Cost estimate
+PPE, $0.003/lead on the free plan (Store pricing read 2026-09-05; a scheduled record raises it to $0.005/lead on 2026-09-14 - read the Actor's Pricing tab), MX verification included; every filter drops rows before billing. 100 leads = at most $0.30, $0.50 after that date.
+
+### Gotcha
+No Google ratings or review counts (OpenStreetMap has none; `rating` fills on ~7% of rows from schema.org markup only). OpenStreetMap is dense on premises-based businesses and thin on van trades: the Actor README measured 171 dentists but 9 plumbers and 5 electricians in the Austin bounding box (2026-08-08). Measured fill with `onlyWithWebsite: true` on that reference run (n=55): phone 96%, verified email 55%; with no filter, email 26% and half the rows had no contact channel at all. Rows are ODbL-licensed and carry an `attribution` string.
+
+---
+
 ## B2B prospect discovery via LinkedIn
 **When:** User wants to find professionals by role, company, or industry.
 


### PR DESCRIPTION
## Gaps this fills

Reading `skills/apify-ultimate-scraper/references/` today:

1. **No Job boards section.** `workflows/job-market-and-recruitment.md` routes every job request to LinkedIn actors (`harvestapi/linkedin-job-search`, `apimaestro/linkedin-job-detail`). An agent asked for "software engineer jobs in Austin from Indeed and Glassdoor", "remote Python jobs", or "watch this company's careers page" has no route.
2. **Lead generation is Maps-only.** `workflows/lead-generation.md` routes local-business contact requests to `compass/crawler-google-places` + the contacts enricher. Correct when the user wants Maps data; there is no option for the user who wants businesses by category and city without Maps.
3. **No creator/influencer contact route.** `influencer-vetting.md` covers vetting but not building a contact list, and the index has no creator-email entry.

## What this adds

| Actor | Where | Why |
|---|---|---|
| `flash_scraper/multi-jobboard-scraper` | new **Job boards** section + job workflow | LinkedIn + Indeed + Glassdoor + The Muse in one run, deduplicated across boards (`found_on_sites`, `duplicate_count`); reads Greenhouse/Lever/Ashby careers boards directly; only-new-jobs monitoring |
| `flash_scraper/remote-job-aggregator` | same | remote-only, 10 keyless boards including HN "Who is hiring" |
| `flash_scraper/local-business-leads` | Google Maps section (as the non-Maps alternative) + lead-gen workflow | OpenStreetMap discovery + each business's own site crawled for MX-verified email, phone, socials |
| `flash_scraper/creator-leads-scraper` | YouTube section + influencer/contact workflows | YouTube keyword discovery, then the linked Instagram/TikTok profiles, one row per creator with a verified email |

Each entry follows the existing table format and states what the actor is best for, including its limits (e.g. TikTok/Instagram cannot be keyword-searched, so discovery is YouTube-first).

## Disclosure

I am the author of all four actors. They are public pay-per-event actors on the Apify Store with no referral or tracking parameters. Happy to trim, reword, or drop any entry the maintainers do not want.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013pXJAWGUfFih86jDhyEQLm