### PR TITLE
Add three community transcript Actors to the ultimate-scraper Actor index

### DIFF
--- a/skills/apify-ultimate-scraper/references/actor-index.md
+++ b/skills/apify-ultimate-scraper/references/actor-index.md
@@ -43,6 +43,7 @@ Tiers: `apify` = Apify-maintained (always prefer), `community` = community-maint
 | apify/facebook-reviews-scraper | apify | page reviews |
 | apify/facebook-hashtag-scraper | apify | hashtag posts |
 | apify/threads-profile-api-scraper | apify | Threads profiles |
+| steadyfetch/facebook-ads-transcript-scraper | community | ad video transcripts, hooks |
 
 ## TikTok
 
@@ -73,6 +74,13 @@ Tiers: `apify` = Apify-maintained (always prefer), `community` = community-maint
 | streamers/youtube-video-scraper-by-hashtag | apify | videos by hashtag |
 | streamers/youtube-video-downloader | apify | video download |
 | curious_coder/youtube-transcript-scraper | community | transcripts, captions |
+| steadyfetch/youtube-channel-transcripts | community | whole-channel transcripts |
+
+## Audio & video
+
+| Actor | Tier | Best for |
+|-------|------|----------|
+| steadyfetch/media-transcriber | community | any URL to text/SRT/VTT |
 
 ## X/Twitter
 


### PR DESCRIPTION
## What this adds

Three `community` rows to `skills/apify-ultimate-scraper/references/actor-index.md`, each filling a gap the index has no row for today. Index only — no other file is touched.

| Section | Row | Why |
|---|---|---|
| YouTube | `steadyfetch/youtube-channel-transcripts` — whole-channel transcripts | The index's only transcript row today is a single-video, captions-only tool. This one takes a handle, URL or `UC…` ID and returns every video on the channel de-duplicated in one run — Shorts and finished live VODs included — reading captions first and falling back to speech-to-text, so an uncaptioned upload still answers. |
| **Audio & video** (new section) | `steadyfetch/media-transcriber` — any URL to text/SRT/VTT | Nothing in the index covers audio that is not on a social platform. A direct media file link works from any host; page links work on the tested podcast and video hosts (Libsyn, Megaphone, Buzzsprout, Acast, Apple Podcasts, Spotify for Creators, Archive.org, SoundCloud, Loom, Twitch VODs, Wistia). |
| Facebook | `steadyfetch/facebook-ads-transcript-scraper` — ad video transcripts, hooks | No Actor in the Facebook section emits a `transcript` field. `apify/facebook-ads-scraper` finds which ads exist; this reads what they say — full script, the first-3-seconds hook, the CTA, and OCR on image ads. It chains directly off that Actor's dataset. |

All three are public on the Apify Store, pay-per-event, charge only on delivery, and are tiered `community` per the file's own convention (`apify` = Apify-maintained, always prefer; `community` = fills gaps).

**Disclosure:** the three `steadyfetch/*` Actors are paid, pay-per-event Actors built and published by the author. No affiliate or referral parameters are used anywhere — the ids above are plain Actor ids.

**One unrelated thing worth a look while you are in this file:** the existing YouTube row `curious_coder/youtube-transcript-scraper` no longer resolves — `GET https://api.apify.com/v2/acts/curious_coder~youtube-transcript-scraper` returns `record-not-found` as of 2026-09-11. I have deliberately left it untouched here rather than widen this PR beyond adding rows, but an agent routed to it will not find it.
